### PR TITLE
update naming inline with dsnp spec hash

### DIFF
--- a/frontend/src/features/BroadcastInfo/PostHashDropdown.tsx
+++ b/frontend/src/features/BroadcastInfo/PostHashDropdown.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement, useState } from 'react';
 import { Dropdown } from 'antd';
 import { CheckCircleTwoTone, EllipsisOutlined } from '@ant-design/icons';
-import { HexString } from '../../types';
+import { Base32EncodedHash } from '../../types';
 import { buildDSNPContentURI } from '../../helpers/dsnp';
 import styles from './PostHashDropdown.module.css';
 
 import type { MenuProps } from 'antd';
 
 interface PostHashDropdownProps {
-  hash: HexString;
+  hash: Base32EncodedHash;
   fromId: string;
 }
 

--- a/frontend/src/helpers/dsnp.ts
+++ b/frontend/src/helpers/dsnp.ts
@@ -1,4 +1,4 @@
-import { HexString } from '../types';
+import { Base32EncodeHash } from '../types';
 
 const DSNP_SCHEMA_REGEX = /^dsnp:\/\//i;
 
@@ -90,6 +90,6 @@ export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
  * @param contentHash - The content hash of the announcement posted by the user
  * @returns A DSNP Content Uri for the given announcement
  */
-export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: HexString): DSNPContentURI => {
+export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: Base32EncodeHash): DSNPContentURI => {
   return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${contentHash}`;
 };

--- a/frontend/src/helpers/dsnp.ts
+++ b/frontend/src/helpers/dsnp.ts
@@ -90,6 +90,9 @@ export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
  * @param contentHash - The content hash of the announcement posted by the user
  * @returns A DSNP Content Uri for the given announcement
  */
-export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: Base32EncodedHash): DSNPContentURI => {
+export const buildDSNPContentURI = (
+  userIdOrUri: DSNPUserId | DSNPUserURI,
+  contentHash: Base32EncodedHash
+): DSNPContentURI => {
   return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${contentHash}`;
 };

--- a/frontend/src/helpers/dsnp.ts
+++ b/frontend/src/helpers/dsnp.ts
@@ -1,4 +1,4 @@
-import { Base32EncodeHash } from '../types';
+import { Base32EncodedHash } from '../types';
 
 const DSNP_SCHEMA_REGEX = /^dsnp:\/\//i;
 
@@ -90,6 +90,6 @@ export const convertToDSNPUserURI = (value: unknown): DSNPUserURI => {
  * @param contentHash - The content hash of the announcement posted by the user
  * @returns A DSNP Content Uri for the given announcement
  */
-export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: Base32EncodeHash): DSNPContentURI => {
+export const buildDSNPContentURI = (userIdOrUri: DSNPUserId | DSNPUserURI, contentHash: Base32EncodedHash): DSNPContentURI => {
   return `dsnp://${convertToDSNPUserId(userIdOrUri)}/${contentHash}`;
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,7 +29,7 @@ export enum FeedTypes {
   OTHER_PROFILE,
 }
 
-export type HexString = string;
+export type Base32EncodeHash = string;
 
 export enum RelationshipStatus {
   FOLLOWING,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -29,7 +29,7 @@ export enum FeedTypes {
   OTHER_PROFILE,
 }
 
-export type Base32EncodeHash = string;
+export type Base32EncodedHash = string;
 
 export enum RelationshipStatus {
   FOLLOWING,


### PR DESCRIPTION
# Purpose
The goal of this PR is to rename content hash from `HexString` to `Base32EncodedHash` to show its type to dev for future hash related use cases
