### PR TITLE
chore: Update Docker Compose files for WEBHOOK_BASE_URL and start-gateway.sh updates

### DIFF
--- a/backend/docker-compose-bare-metal.yaml
+++ b/backend/docker-compose-bare-metal.yaml
@@ -3,7 +3,6 @@ x-bare-metal-common-environment: &common-environment
   REDIS_URL: 'redis://redis:6379'
   PROVIDER_ID: 1
   PROVIDER_ACCOUNT_SEED_PHRASE: '//Alice'
-  WEBHOOK_BASE_URL: 'http://host.docker.internal:3002/webhooks'
   WEBHOOK_FAILURE_THRESHOLD: 3
   WEBHOOK_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_MAX_RETRIES: 4
@@ -31,7 +30,7 @@ x-content-watcher-env: &content-watcher-env
   STARTING_BLOCK: 1
   BLOCKCHAIN_SCAN_INTERVAL_MINUTES: 1
   WEBHOOK_FAILURE_THRESHOLD: 4
-  PROVIDER_BASE_URL: 'http://docker.host.internal:3002/webhooks/content-watcher/announcements'
+  PROVIDER_BASE_URL: 'http://host.docker.internal:3002/webhooks/content-watcher/announcements'
 
 x-graph-service-env: &graph-service-env
   DEBOUNCE_SECONDS: 10
@@ -41,7 +40,7 @@ x-graph-service-env: &graph-service-env
 
 x-account-service-env: &account-service-env
   FREQUENCY_HTTP_URL: 'http://localhost:9944'
-  PROVIDER_BASE_URL: 'http://host.docker.internal:3002/webhooks/account-service'
+  WEBHOOK_BASE_URL: 'http://host.docker.internal:3002/webhooks/account-service'
 
 services:
   redis:

--- a/backend/docker-compose-bare-metal.yaml
+++ b/backend/docker-compose-bare-metal.yaml
@@ -30,7 +30,6 @@ x-content-watcher-env: &content-watcher-env
   STARTING_BLOCK: 1
   BLOCKCHAIN_SCAN_INTERVAL_MINUTES: 1
   WEBHOOK_FAILURE_THRESHOLD: 4
-  PROVIDER_BASE_URL: 'http://host.docker.internal:3002/webhooks/content-watcher/announcements'
 
 x-graph-service-env: &graph-service-env
   DEBOUNCE_SECONDS: 10

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -1,0 +1,35 @@
+services:
+  content-publishing-service-api:
+    image: content-publishing-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  content-publishing-service-worker:
+    image: content-publishing-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  content-watcher-service:
+    image: content-watcher-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  graph-service-api:
+    image: graph-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  graph-service-worker:
+    image: graph-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  account-service-api:
+    image: account-service:latest
+    platform: linux/arm64
+    pull_policy: never
+
+  account-service-worker:
+    image: account-service:latest
+    platform: linux/arm64
+    pull_policy: never

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ x-common-environment: &common-environment
   REDIS_URL: 'redis://redis:6379'
   PROVIDER_ID: ${PROVIDER_ID}
   PROVIDER_ACCOUNT_SEED_PHRASE: ${PROVIDER_ACCOUNT_SEED_PHRASE}
-  WEBHOOK_BASE_URL: 'http://social-app-template-backend:3001/webhooks'
   WEBHOOK_FAILURE_THRESHOLD: 3
   WEBHOOK_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_MAX_RETRIES: 4
@@ -43,7 +42,7 @@ x-graph-service-env: &graph-service-env
 x-account-service-env: &account-service-env
   BLOCKCHAIN_SCAN_INTERVAL_SECONDS: 1
   TRUST_UNFINALIZED_BLOCKS: true
-  PROVIDER_BASE_URL: 'http://social-app-template-backend:3001/webhooks/account-service'
+  WEBHOOK_BASE_URL: 'http://social-app-template-backend:3001/webhooks/account-service'
 
 x-social-app-template-backend: &social-app-template-backend
   ACCOUNT_SERVICE_URL: 'http://account-service-api:3000'
@@ -52,6 +51,7 @@ x-social-app-template-backend: &social-app-template-backend
   GRAPH_SERVICE_URL: 'http://graph-service-api:3000'
   IPFS_UA_GATEWAY_URL: ${IPFS_UA_GATEWAY_URL}
   NODE_ENV: development
+  WEBHOOK_BASE_URL: 'http://social-app-template-backend:3001/webhooks'
 
 x-social-app-template-frontend: &social-app-template-frontend
   REACT_APP_BACKEND_URL: 'http://localhost:3001'
@@ -75,7 +75,7 @@ services:
     # Other options you may want to add depending on your test scenario.
     environment:
       - SEALING_MODE=interval
-      - SEALING_INTERVAL=12
+      - SEALING_INTERVAL=1
     #   - CREATE_EMPTY_BLOCKS=true
     # The 'command' may contain additional CLI options to the Frequency node,
     # such as:

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -22,7 +22,7 @@ if [ -f .env-saved ]; then
     echo -e "Found saved environment from a previous run:\n"
     cat .env-saved
     echo
-    read -p  "Do you want to re-use the saved paramters? [y]: " REUSE_SAVED
+    read -p  "Do you want to re-use the saved parameters? [Y/n]: " REUSE_SAVED
     REUSE_SAVED=${REUSE_SAVED:-y}
 
     if [[ ${REUSE_SAVED} =~ ^[Yy] ]]

--- a/stop-gateway.sh
+++ b/stop-gateway.sh
@@ -25,7 +25,7 @@ then
     docker volume rm ${COMPOSE_PROJECT_NAME}_frontend_node_cache
     if [[ ! $TESTNET_ENV =~ ^[Yy]$ ]]
     then
-        docker volume rm $(basename "$(pwd)" | tr '[:upper:]' '[:lower:]')_chainstorage
+        docker volume rm ${COMPOSE_PROJECT_NAME}_chainstorage
     fi
 else
     echo "Leaving Docker volumes alone."


### PR DESCRIPTION
# Purpose
The goal of this PR is finish integrating the WEBHOOK_BASE_URL change for account service and update `start-gateway.sh` to allow for easily testing with locally built docker container images.

## Solution
SAT environment variables need to be updated for a new `account-service` container image.
`start-gateway.sh` is updated with some bug fixes and an additional environment variable to use local docker images instead of pulling from docker hub. 

### Change summary
- Update `docker-compose.yaml` environment variables to be correct for the account service change to using `WEBHOOK_BASE_URL`
- Fixed a typo in `docker-compose-bare-metal.yaml` [this probably requires more testing which is out of scope for v1.0]
- Add `docker-compose-local.yaml` docker override file to allow using locally built docker images.
- `start-gateway.sh`
  - Make 'y' the default when `.env-saved` is detected.
  - Fixed bug when not changing 'IPFS' settings and getting null values.
  - Added `DEV_CONTAINERS` variable to allow for using local docker images.
- `stop-gateway.sh` updated to use project name to delete a volume.


## Steps to Verify IPFS settings bug
1. `rm .env-saved`
2. Execute `./start-gateway.sh`
3. Enter all default values and say no to IPFS settings changes.
4. Verify that the IPFS values are not null.

## Steps to Verify WEBHOOK_BASE_URL and local docker image changes
1. Edit `.env-saved` and set `DEV_CONTAINERS="true"`
2. Execute `./start-gateway.sh`
3. Verify that the local containers are used. You can check the image name in Docker Desktop and you will see the following message:
```bash
Starting services with local docker containers...
```
4. Verify that SAT works as expected with all containers running.
