### PR TITLE
feat: add DOCKER_TAG as a configurable parameter in startup of services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,7 +104,7 @@ services:
       - 'portical.upnp.forward=4401:4401'
 
   content-publishing-service-api:
-    image: projectlibertylabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     ports:
@@ -118,7 +118,7 @@ services:
       - social-app-backend
 
   content-publishing-service-worker:
-    image: projectlibertylabs/content-publishing-service:latest
+    image: projectlibertylabs/content-publishing-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     environment:
@@ -131,7 +131,7 @@ services:
       - social-app-backend
 
   content-watcher-service:
-    image: projectlibertylabs/content-watcher-service:latest
+    image: projectlibertylabs/content-watcher-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     ports:
@@ -145,7 +145,7 @@ services:
       - social-app-backend
 
   graph-service-api:
-    image: projectlibertylabs/graph-service:latest
+    image: projectlibertylabs/graph-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     ports:
@@ -159,7 +159,7 @@ services:
       - social-app-backend
 
   graph-service-worker:
-    image: projectlibertylabs/graph-service:latest
+    image: projectlibertylabs/graph-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     environment:
@@ -171,7 +171,7 @@ services:
       - social-app-backend
 
   account-service-api:
-    image: projectlibertylabs/account-service:latest
+    image: projectlibertylabs/account-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     ports:
@@ -185,7 +185,7 @@ services:
       - social-app-backend
 
   account-service-worker:
-    image: projectlibertylabs/account-service:latest
+    image: projectlibertylabs/account-service:${DOCKER_TAG}
     platform: linux/amd64
     pull_policy: always
     command: worker
@@ -209,7 +209,7 @@ services:
       - 3002:3001
     environment:
       <<: [*common-environment, *social-app-template-backend]
-      IPFS_GATEWAY_URL: "http://ipfs:8080"
+      IPFS_GATEWAY_URL: 'http://ipfs:8080'
     volumes:
       - ./backend:/app
       - ${CONTENT_DB_VOLUME}:/app/db

--- a/start-gateway.sh
+++ b/start-gateway.sh
@@ -61,6 +61,8 @@ then
 
 EOI
     echo "COMPOSE_PROJECT_NAME='gateway'" >> .env-saved
+    read -p "Enter a tag to use to pull the Gateway Docker images [latest]: " tag
+    echo "DOCKER_TAG=${tag:-latest}" >> .env-saved
     # Ask the user if they want to start on testnet or local
     echo "Do you want to start on Frequency Paseo Testnet [y/n]:"
     read TESTNET_ENV


### PR DESCRIPTION
This PR adds a prompt to `./start-gateway.sh` that allows the user to override the default `latest` tag for the Docker images with a specific tag of their choosing.