### PR TITLE
UI Customization Options in Startup script

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,8 @@ x-social-app-template-backend: &social-app-template-backend
 
 x-social-app-template-frontend: &social-app-template-frontend
   REACT_APP_BACKEND_URL: 'http://localhost:${SERVICE_PORT_8}'
+  REACT_APP_TITLE: ${REACT_APP_TITLE}
+  REACT_APP_HEADER_BG_COLOR: ${REACT_APP_HEADER_BG_COLOR}
 
 services:
   redis:

--- a/frontend/src/features/Header/Header.tsx
+++ b/frontend/src/features/Header/Header.tsx
@@ -31,11 +31,16 @@ const Header = ({ loggedInAccount, login, logout }: HeaderProps): ReactElement =
     login(account, providerInfo);
   };
 
+  // Read the title from the environment variable
+  console.log(process.env.REACT_APP_TITLE);
+  const title = process.env.REACT_APP_TITLE || 'Social Web Demo';
+  const headerBgColor = process.env.REACT_APP_HEADER_BG_COLOR || '#ffffff';
+
   return (
-    <div className={styles.root}>
+    <div className={styles.root} style={{ backgroundColor: headerBgColor }}>
       <Flex align={'center'} justify={'space-between'} className={styles.container}>
         <Title level={1} className={styles.title}>
-          Social Web Demo
+          {title}
         </Title>
         {loggedInAccount && logout ? (
           <Popover

--- a/start.sh
+++ b/start.sh
@@ -123,17 +123,28 @@ ask_and_save() {
     local var_name=${1}
     local prompt=${2}
     local default_value=${3}
+    local hide_input=${4:-false}
     local value=
+    local input=
+
     if [ -z "${default_value}" ]
     then
-        input=
-        while [ -z "${input}" ]
-        do
+        if [ "${hide_input}" = true ]
+        then
+            read -rsp $'\n'"${prompt} (INPUT HIDDEN): " input
+            echo
+        else
             read -rp $'\n'"${prompt}: " input
-        done
+        fi
         value=${input}
     else
-        read -rp $'\n'"${prompt} [${default_value}]: " input
+        if [ "${hide_input}" = true ]
+        then
+            read -rsp $'\n'"${prompt} [${default_value}] (INPUT HIDDEN): " input
+            echo
+        else
+            read -rp $'\n'"${prompt} [${default_value}]: " input
+        fi
         value=${input:-$default_value}
     fi
     echo "${var_name}=\"${value}\"" >> ${ENV_FILE}
@@ -319,7 +330,7 @@ ${OUTPUT} << EOI
 
 EOI
         ask_and_save PROVIDER_ID "Enter Provider ID" "$DEFAULT_PROVIDER_ID"
-        ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE"
+        ask_and_save PROVIDER_ACCOUNT_SEED_PHRASE "Enter Provider Seed Phrase" "$DEFAULT_PROVIDER_ACCOUNT_SEED_PHRASE" true
     else
         echo "PROVIDER_ID=1" >> ${ENV_FILE}
         echo "PROVIDER_ACCOUNT_SEED_PHRASE=\"//Alice\"" >> ${ENV_FILE}
@@ -341,8 +352,8 @@ EOI
         EXTERNAL_IPFS=1
         ask_and_save IPFS_ENDPOINT "Enter the IPFS Endpoint" "$DEFAULT_IPFS_ENDPOINT"
         ask_and_save IPFS_GATEWAY_URL "Enter the IPFS Gateway URL" "$DEFAULT_IPFS_GATEWAY_URL"
-        ask_and_save IPFS_BASIC_AUTH_USER "Enter the IPFS Basic Auth User" "$DEFAULT_IPFS_BASIC_AUTH_USER"
-        ask_and_save IPFS_BASIC_AUTH_SECRET "Enter the IPFS Basic Auth Secret" "$DEFAULT_IPFS_BASIC_AUTH_SECRET"
+        ask_and_save IPFS_BASIC_AUTH_USER "Enter the IPFS Basic Auth User" "$DEFAULT_IPFS_BASIC_AUTH_USER" true
+        ask_and_save IPFS_BASIC_AUTH_SECRET "Enter the IPFS Basic Auth Secret" "$DEFAULT_IPFS_BASIC_AUTH_SECRET" true
         ask_and_save IPFS_UA_GATEWAY_URL "Enter the browser-resolveable IPFS UA Gateway URL" "$DEFAULT_IPFS_UA_GATEWAY_URL"
     else
     # Add the IPFS settings to the .env-saved file so defaults work with local testing

--- a/start.sh
+++ b/start.sh
@@ -297,13 +297,12 @@ EOI
     ask_and_save REACT_APP_TITLE "Enter the title of the application" "Social Web Demo"
 
     # Allow different instances to have different background colors in the header
+    echo
 ${OUTPUT} << EOI
 Select the background color of the header:
 EOI
     selected_color_hex=$(select_color)
     echo "REACT_APP_HEADER_BG_COLOR=${selected_color_hex}" >> ${ENV_FILE}
-
-    # ask_and_save REACT_APP_HEADER_BG_COLOR "Enter the background color of the header" "#282c34"
 
     ask_and_save FREQUENCY_URL "Enter the Frequency RPC URL" "$DEFAULT_FREQUENCY_URL"
     ask_and_save FREQUENCY_HTTP_URL "Enter the Frequency HTTP RPC URL" "$DEFAULT_FREQUENCY_HTTP_URL"

--- a/stop.sh
+++ b/stop.sh
@@ -30,6 +30,11 @@ if [ -n "${1}" ]; then
     ENV_FILE=${1}
 fi
 
+if [[ -n $ENV_FILE ]]; then
+    echo -e "Using environment file: $ENV_FILE\n"
+fi
+
+
 # Export the variables that are used in the docker-compose.yaml file
 if [ -f ${ENV_FILE} ]; then
     set -a; source ${ENV_FILE}; set +a

--- a/stop.sh
+++ b/stop.sh
@@ -1,8 +1,31 @@
 #!/bin/bash
 # Stop all services and optionally remove specified volumes to remove all state and start fresh
+BASE_DIR=${HOME}/.projectliberty
+BASE_NAME=social-app-template
+ENV_FILE=${BASE_DIR}/.env.${BASE_NAME}
 
-ENV_FILE=.env-saved
+# Usage: ./stop.sh [options]
+# Options:
+#   -h, --help                 Show this help message and exit
+#   -n, --name                 Specify the project name
 
+# Function to display help message
+show_help() {
+    echo "Usage: ./stop.sh [options]"
+    echo "Options:"
+    echo "  -h, --help                 Show this help message and exit"
+    echo "  -n, --name                 Specify the project name"
+}
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -h|--help) show_help; exit 0 ;;
+        -n|--name) BASE_NAME="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; show_help; exit 1 ;;
+    esac
+    shift
+done
 if [ -n "${1}" ]; then
     ENV_FILE=${1}
 fi


### PR DESCRIPTION
# Purpose
To make demos clearer and slightly more custom, lets add some basic customization options to the startup script:

- [x] Setting the name of the application: Default still "Social Web Demo"
- [x] Setting/choosing a color / color pallet?

Closes #151 

## Solution
The `start.sh` script should ask a few questions, save the values in the env file and make sure that those values are passed through to the docker environment and correctly processed by the frontend to change the display.

### Change summary
- Updated `start.sh` to ask for name to appear in header and background color
- Updated `stop.sh` to match `start.sh` updates
- Updated `header.tsx` to get the name and color values from the environment
- Updated `docker-compose.yaml` to pass through the env values
- Add code to redact sensitive values when displaying the env file
- Add code to hide the input of sensitive values

## Steps to Verify
1. Use `start.sh` and start from scratch to create a new env file by answering the questions.
2. Verify the demo reflects the correct changes.


## Additional details / screenshot
This example shows a name change and a light green background color:
![Screenshot 2024-08-22 at 10 37 01](https://github.com/user-attachments/assets/27d44941-e520-44df-a069-b1583bbcf4ab)
![Screenshot 2024-08-22 at 12 56 19](https://github.com/user-attachments/assets/631c227b-d554-4d61-bb44-c97c87c5c75f)

