### PR TITLE
fix: only fetch content in which we are interested from DB, instead of filtering results after

### DIFF
--- a/backend/repositories/ContentRepository.ts
+++ b/backend/repositories/ContentRepository.ts
@@ -101,7 +101,7 @@ function getFilter(options?: ContentSearchParametersType, sort?: ContentOrdering
     }
 
     if (options.msaIds && options.msaIds.length > 0) {
-      conditionals.push(`"announcement_json"->>'$.announcement.fromId IN  (SELECT value from json_each(:msaIds))`);
+      conditionals.push(`"announcement_json"->>'$.announcement.fromId' IN  (SELECT value from json_each(:msaIds))`);
     }
 
     if (options.contentHash) {

--- a/backend/services/ContentService.ts
+++ b/backend/services/ContentService.ts
@@ -17,11 +17,11 @@ export async function getOwnContent(msaId: string, { newestBlockNumber, oldestBl
   const oldest = Math.max(1, oldestBlockNumber || 1, newest - 45_000); // 45k blocks at a time max
 
   try {
-    const posts = await getPostsInRange(newest, oldest);
+    const posts = await getPostsInRange(newest, oldest, msaId);
     const response: T.Paths.GetUserFeed.Responses.$200 = {
       newestBlockNumber: newest,
       oldestBlockNumber: oldest,
-      posts: posts.filter((x) => x.fromId === msaId),
+      posts,
     };
     return response;
   } catch (e) {

--- a/backend/services/feed.ts
+++ b/backend/services/feed.ts
@@ -35,11 +35,12 @@ function toReply(entity: AnnouncementEntity): Reply {
   };
 }
 
-async function getPostsForBlockRange({ from, to }: BlockRange): Promise<Post[]> {
+async function getPostsForBlockRange({ from, to }: BlockRange, msaId?: string): Promise<Post[]> {
   const announcements = ContentRepository.getAnnouncementsWithContent({
     blockFrom: from,
     blockTo: to,
     announcementTypes: [AnnouncementType.Broadcast],
+    msaIds: msaId ? [msaId] : [],
   });
 
   const posts: Post[] = [];
@@ -101,8 +102,12 @@ async function getPostContent(msg: AnnouncementEntity): Promise<Post | undefined
   }
 }
 
-export async function getPostsInRange(newestBlockNumber: number, oldestBlockNumber: number): Promise<Post[]> {
-  return getPostsForBlockRange({ from: oldestBlockNumber, to: newestBlockNumber });
+export async function getPostsInRange(
+  newestBlockNumber: number,
+  oldestBlockNumber: number,
+  msaId?: string
+): Promise<Post[]> {
+  return getPostsForBlockRange({ from: oldestBlockNumber, to: newestBlockNumber }, msaId);
 }
 
 export async function getSpecificContent(msaId: string, contentHash: string): Promise<Post | undefined> {

--- a/stop.sh
+++ b/stop.sh
@@ -2,7 +2,7 @@
 # Stop all services and optionally remove specified volumes to remove all state and start fresh
 BASE_DIR=${HOME}/.projectliberty
 BASE_NAME=social-app-template
-ENV_FILE=${BASE_DIR}/.env.${BASE_NAME}
+ENV_FILE="${BASE_DIR}/.env.${BASE_NAME}"
 
 # Usage: ./stop.sh [options]
 # Options:
@@ -26,12 +26,12 @@ while [[ "$#" -gt 0 ]]; do
     esac
     shift
 done
-if [ -n "${1}" ]; then
-    ENV_FILE=${1}
-fi
 
-if [[ -n $ENV_FILE ]]; then
-    echo -e "Using environment file: $ENV_FILE\n"
+if [ ! -f "${BASE_DIR}/.env.${BASE_NAME}" ]; then
+   echo -e "Unable to find '${BASE_DIR}/.env.${BASE_NAME}'; using '${ENV_FILE}' instead.\n"
+else
+   ENV_FILE="${BASE_DIR}/.env.${BASE_NAME}"
+    echo -e "Using environment file: '${ENV_FILE}'\n"
 fi
 
 


### PR DESCRIPTION
# Description
- When fetching content for (a) specific msaId(s), use the SQL query parameters to retrieve the appropriate results, instead of fetching content for all MSAs and then filtering the result.
- Small fix to `stop.sh` to work properly with non-default named projects (ie, when invoked with `-n <name>`)

Closes #157 