### PR TITLE
fix: update docker-compose for new gateway images

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -287,3 +287,19 @@ function prefix_postfix_values() {
 
     echo ${str}
 }
+
+###################################################################################
+# is_frequency_ready
+#
+# Description: Runs a command to check the health status of the 'frequency' service
+#
+###################################################################################
+function is_frequency_ready {
+    health=$( docker compose -p ${COMPOSE_PROJECT_NAME} ps --format '{{.Health}}' frequency )
+    if [ "${health}" = 'healthy' ]
+    then
+        return 0
+    fi
+
+    return 1
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ x-common-environment: &common-environment
   DEBUG: true
 
 x-content-publishing-env: &content-publishing-env
-  START_PROCESS: api
+  START_PROCESS: content-publishing-api
   FILE_UPLOAD_MAX_SIZE_IN_BYTES: 2000000000
   ASSET_EXPIRATION_INTERVAL_SECONDS: 300
   BATCH_INTERVAL_SECONDS: 12
@@ -128,7 +128,7 @@ services:
     pull_policy: always
     environment:
       <<: [*common-environment, *content-publishing-env]
-      START_PROCESS: worker
+      START_PROCESS: content-publishing-worker
     depends_on:
       - redis
     networks:
@@ -159,7 +159,7 @@ services:
       - ${SERVICE_PORT_2}:3000
     environment:
       <<: [*common-environment, *graph-service-env]
-      START_PROCESS: api
+      START_PROCESS: graph-api
     depends_on:
       - redis
     networks:
@@ -173,7 +173,7 @@ services:
     pull_policy: always
     environment:
       <<: [*common-environment, *graph-service-env]
-      START_PROCESS: worker
+      START_PROCESS: graph-worker
     depends_on:
       - redis
     networks:
@@ -187,7 +187,7 @@ services:
     pull_policy: always
     ports:
       - ${SERVICE_PORT_3}:3000
-    command: api
+    command: account-api
     environment:
       <<: [*common-environment, *account-service-env]
     depends_on:
@@ -201,7 +201,7 @@ services:
     image: projectlibertylabs/account-service:${DOCKER_TAG:-latest}
     platform: linux/amd64
     pull_policy: always
-    command: worker
+    command: account-worker
     environment:
       <<: [*common-environment, *account-service-env]
     depends_on:

--- a/start.sh
+++ b/start.sh
@@ -277,9 +277,23 @@ docker compose ${COMPOSE_CMD} ${PROFILE_CMD} up -d
 
 if [ ${SKIP_CHAIN_SETUP} != true -a ${TESTNET_ENV} != true ]
 then
-    # Run npm run local:init
-    echo "Running npm run local:init to provision Provider with capacity, etc..."
-    ( cd backend && npm run local:init )
+    # Wait 1 minute for Frequency node to be ready
+    health_attempts=0
+    while (( ${health_attempts} < 60 )) && ! is_frequency_ready
+    do
+        (( health_attempts += 1 ))
+        echo "Waiting for Frequency node to respond..."
+        sleep 1
+    done
+
+    if is_frequency_ready
+    then
+        # Run npm run local:init
+        echo "Running npm run local:init to provision Provider with capacity, etc..."
+        ( cd backend && npm run local:init )
+    else
+        echo "Timed out waiting for Frequency node to be ready" >&2
+    fi
 fi
 
 if [[ ${PROFILES} =~ frontend ]]


### PR DESCRIPTION
# Purpose
The goal of this PR is update the Docker tooling for spinning up Gateway services to match Gateway v1.0.3