### PR TITLE
Update to use the versioned URL for SIWF

### DIFF
--- a/backend/docker-compose-bare-metal.yaml
+++ b/backend/docker-compose-bare-metal.yaml
@@ -9,7 +9,7 @@ x-bare-metal-common-environment: &common-environment
   HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_SUCCESS_THRESHOLD: 10
   CAPACITY_LIMIT: '{"type":"percentage", "value":80}'
-  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/ui'
+  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/v1/ui'
   SIWF_DOMAIN: 'localhost'
   IPFS_ENDPOINT: 'http://ipfs:5001'
   IPFS_GATEWAY_URL: 'https://ipfs.io/ipfs/[CID]'

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -11,7 +11,7 @@ x-common-environment: &common-environment
   HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_SUCCESS_THRESHOLD: 10
   CAPACITY_LIMIT: '{"type":"percentage", "value":80}'
-  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/ui'
+  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/v1/ui'
   SIWF_DOMAIN: 'localhost'
   IPFS_ENDPOINT: 'http://ipfs:5001'
   IPFS_GATEWAY_URL: 'https://ipfs.io/ipfs/[CID]'

--- a/backend/environment/env.social-app-backend.template
+++ b/backend/environment/env.social-app-backend.template
@@ -35,7 +35,7 @@ GRAPH_SERVICE_URL=http://0.0.0.0:3012
 CHAIN_ENVIRONMENT=dev
 
 # URL for the Sign-In With Frequency UI
-SIWF_URL=https://projectlibertylabs.github.io/siwf/ui
+SIWF_URL=https://projectlibertylabs.github.io/siwf/v1/ui
 
 # Domain for the Sign-in with Frequency login payload
 SIWF_DOMAIN=localhost

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,8 @@ x-common-environment: &common-environment
   HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_SUCCESS_THRESHOLD: 10
   CAPACITY_LIMIT: '{"type":"percentage", "value":80}'
-  SIWF_URL: "https://projectlibertylabs.github.io/siwf/v1/ui"
-  SIWF_DOMAIN: "localhost"
+  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/v1/ui'
+  SIWF_DOMAIN: 'localhost'
   IPFS_ENDPOINT: ${IPFS_ENDPOINT}
   IPFS_GATEWAY_URL: ${IPFS_GATEWAY_URL}
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,8 @@ x-common-environment: &common-environment
   HEALTH_CHECK_MAX_RETRY_INTERVAL_SECONDS: 10
   HEALTH_CHECK_SUCCESS_THRESHOLD: 10
   CAPACITY_LIMIT: '{"type":"percentage", "value":80}'
-  SIWF_URL: 'https://projectlibertylabs.github.io/siwf/ui'
-  SIWF_DOMAIN: 'localhost'
+  SIWF_URL: "https://projectlibertylabs.github.io/siwf/v1/ui"
+  SIWF_DOMAIN: "localhost"
   IPFS_ENDPOINT: ${IPFS_ENDPOINT}
   IPFS_GATEWAY_URL: ${IPFS_GATEWAY_URL}
   IPFS_BASIC_AUTH_USER: ${IPFS_BASIC_AUTH_USER}


### PR DESCRIPTION
# Purpose
The goal of this PR is to update SAT to use the newer versioned SIWF URLs.

See https://github.com/ProjectLibertyLabs/siwf/pull/172 for details

(Yes it will work either way)

![image](https://github.com/user-attachments/assets/07b7ccfb-de9c-489f-89c7-82e30781f003)