### PR TITLE
feat(siwf): add siwf v2

### DIFF
--- a/backend/controllers/AuthController.ts
+++ b/backend/controllers/AuthController.ts
@@ -25,8 +25,8 @@ export class AuthController extends BaseController {
     this.router.get('/siwf', this.getSiwf.bind(this));
     this.router.get('/account', this.getAccount.bind(this));
     this.router.post('/login', this.postLogin.bind(this));
-    this.router.get('/login/v2/siwf', this.getLoginV2Swif.bind(this));
-    this.router.post('/login/v2/siwf/verify', this.postLoginV2Swif.bind(this));
+    this.router.get('/login/v2/siwf', this.getLoginV2Siwf.bind(this));
+    this.router.post('/login/v2/siwf/verify', this.postLoginV2Siwf.bind(this));
     this.router.post('/logout', validateAuthToken, this.postLogout.bind(this));
   }
 
@@ -38,11 +38,10 @@ export class AuthController extends BaseController {
     return null;
   }
 
-  public async postLoginV2Swif(req: Request, res: Response) {
+  public async postLoginV2Siwf(req: Request, res: Response) {
     try {
       const payload = await AccountService.getInstance().then((service) => service.verifyFrequencyAccessAuth(req.body));
 
-      console.log('payload', payload);
       res.json(payload);
     } catch (e) {
       if (e instanceof HttpError) {
@@ -53,7 +52,7 @@ export class AuthController extends BaseController {
     }
   }
 
-  public async getLoginV2Swif(req: Request, res: Response) {
+  public async getLoginV2Siwf(req: Request, res: Response) {
     try {
       const HOSTNAME = 'localhost';
       const PORT = Config.instance().port;

--- a/backend/openapi-specs/account.openapi.json
+++ b/backend/openapi-specs/account.openapi.json
@@ -1,6 +1,107 @@
 {
   "openapi": "3.0.0",
   "paths": {
+    "/v2/accounts/siwf": {
+      "get": {
+        "operationId": "AccountsControllerV2_getRedirectUrl",
+        "summary": "Get the Sign In With Frequency Redirect URL",
+        "parameters": [
+          {
+            "name": "credentials",
+            "required": false,
+            "in": "query",
+            "description": "List of credentials using the types: \"VerifiedGraphKeyCredential\", \"VerifiedEmailAddressCredential\", and \"VerifiedPhoneNumberCredential\". Note that Contact related verifiable credentials will be nested into an anyOf request form.",
+            "schema": {
+              "example": [
+                "VerifiedGraphKeyCredential",
+                "VerifiedEmailAddressCredential",
+                "VerifiedPhoneNumberCredential"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "permissions",
+            "required": false,
+            "in": "query",
+            "description": "The list of permissions using the Frequency Schema names and versions. Pattern: `<namespace>.<name>@v<version integer>` e.g. `dsnp.broadcast@v2`",
+            "schema": {
+              "example": [
+                "dsnp.broadcast@v2",
+                "dsnp.private-follows@v1",
+                "dsnp.reply@v2",
+                "dsnp.reaction@v1",
+                "dsnp.tombstone@v2",
+                "dsnp.update@v2",
+                "frequency.default-token-address@v1"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "callbackUrl",
+            "required": true,
+            "in": "query",
+            "description": "The URL that will be called when the authentication process is completed",
+            "schema": {
+              "example": "http://localhost:3000/login/callback",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SIWF Redirect URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletV2RedirectResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "v2/accounts"
+        ]
+      },
+      "post": {
+        "operationId": "AccountsControllerV2_postSignInWithFrequency",
+        "summary": "Process the result of a Sign In With Frequency v2 callback",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WalletV2LoginRequestDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signed in successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WalletV2LoginResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "v2/accounts"
+        ]
+      }
+    },
     "/v1/accounts/siwf": {
       "get": {
         "operationId": "AccountsControllerV1_getSIWFConfig",
@@ -63,8 +164,8 @@
             "required": true,
             "in": "path",
             "description": "Msa Id of requested account",
-            "example": "2",
             "schema": {
+              "example": "2",
               "type": "string"
             }
           }
@@ -96,8 +197,8 @@
             "required": true,
             "in": "path",
             "description": "AccountId in hex or SS58 format",
-            "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
             "schema": {
+              "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
               "type": "string"
             }
           }
@@ -129,8 +230,8 @@
             "required": true,
             "in": "path",
             "description": "AccountId in hex or SS58 format",
-            "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
             "schema": {
+              "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
               "type": "string"
             }
           }
@@ -194,8 +295,8 @@
             "required": true,
             "in": "path",
             "description": "MSA Id of the user requesting the delegation",
-            "example": "3",
             "schema": {
+              "example": "3",
               "type": "string"
             }
           }
@@ -227,8 +328,8 @@
             "required": true,
             "in": "path",
             "description": "MSA Id of the user requesting the delegation",
-            "example": "3",
             "schema": {
+              "example": "3",
               "type": "string"
             }
           },
@@ -237,8 +338,8 @@
             "required": false,
             "in": "path",
             "description": "MSA Id of the provider to whom the requesting user wishes to delegate",
-            "example": "1",
             "schema": {
+              "example": "1",
               "type": "string"
             }
           }
@@ -270,8 +371,8 @@
             "required": true,
             "in": "path",
             "description": "Msa Id of requested account",
-            "example": "2",
             "schema": {
+              "example": "2",
               "type": "string"
             }
           }
@@ -303,8 +404,8 @@
             "required": true,
             "in": "path",
             "description": "AccountId in hex or SS58 format",
-            "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
             "schema": {
+              "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
               "type": "string"
             }
           },
@@ -313,8 +414,8 @@
             "required": true,
             "in": "path",
             "description": "Msa Id of provider",
-            "example": "1",
             "schema": {
+              "example": "1",
               "type": "string"
             }
           }
@@ -385,7 +486,14 @@
         },
         "responses": {
           "200": {
-            "description": "Handle creation request enqueued"
+            "description": "Handle creation request enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -410,7 +518,14 @@
         },
         "responses": {
           "200": {
-            "description": "Handle change request enqueued"
+            "description": "Handle change request enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -428,16 +543,23 @@
             "required": true,
             "in": "path",
             "description": "newHandle in the request",
-            "example": "handle",
             "schema": {
               "minLength": 3,
+              "example": "handle",
               "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Returned an encoded ClaimHandlePayload for signing"
+            "description": "Returned an encoded ClaimHandlePayload for signing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChangeHandlePayloadRequest"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -455,15 +577,22 @@
             "required": true,
             "in": "path",
             "description": "Msa Id of requested account",
-            "example": "2",
             "schema": {
+              "example": "2",
               "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Found a handle"
+            "description": "Found a handle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HandleResponseDto"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -488,7 +617,14 @@
         },
         "responses": {
           "200": {
-            "description": "Found public keys"
+            "description": "Found public keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -506,15 +642,22 @@
             "required": true,
             "in": "path",
             "description": "Msa Id of requested account",
-            "example": "2",
             "schema": {
+              "example": "2",
               "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Found public keys"
+            "description": "Found public keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeysResponse"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -532,8 +675,8 @@
             "required": true,
             "in": "query",
             "description": "MSA Id representing the target of this request",
-            "example": "3",
             "schema": {
+              "example": "3",
               "type": "string"
             }
           },
@@ -542,15 +685,22 @@
             "required": true,
             "in": "query",
             "description": "New public key to be added to the account (32-byte value in hex format)",
-            "example": "0x0ed2f8c714efcac51ca2325cfe95637e5e0b898ae397aa365978b7348a717d0b",
             "schema": {
+              "example": "0x0ed2f8c714efcac51ca2325cfe95637e5e0b898ae397aa365978b7348a717d0b",
               "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "Returned an encoded StatefulStorageItemizedSignaturePayloadV2 for signing"
+            "description": "Returned an encoded StatefulStorageItemizedSignaturePayloadV2 for signing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddNewPublicKeyAgreementPayloadRequest"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -575,7 +725,14 @@
         },
         "responses": {
           "200": {
-            "description": "Add new key request enqueued"
+            "description": "Add new key request enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponse"
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -639,6 +796,201 @@
   "servers": [],
   "components": {
     "schemas": {
+      "WalletV2RedirectResponseDto": {
+        "type": "object",
+        "properties": {
+          "signedRequest": {
+            "type": "string",
+            "description": "The base64url encoded JSON stringified signed request",
+            "example": "eyJyZXF1ZXN0ZWRTaWduYXR1cmVzIjp7InB1YmxpY0tleSI6eyJlbmNvZGVkVmFsdWUiOiJmNmNMNHdxMUhVTngxMVRjdmRBQk5mOVVOWFhveUg0N21WVXdUNTl0elNGUlc4eURIIiwiZW5jb2RpbmciOiJiYXNlNTgiLCJmb3JtYXQiOiJzczU4IiwidHlwZSI6IlNyMjU1MTkifSwic2lnbmF0dXJlIjp7ImFsZ28iOiJTcjI1NTE5IiwiZW5jb2RpbmciOiJiYXNlMTYiLCJlbmNvZGVkVmFsdWUiOiIweDA0MDdjZTgxNGI3Nzg2MWRmOTRkMTZiM2ZjYjMxN2QzN2EwN2FiYzJhN2Y5Y2Q3YzAyY2MyMjUyOWVlN2IzMmQ1Njc5NWY4OGJkNmI0YWQxMDZiNzJiOTFiNjI0NmE3ODM2NzFiY2QyNGNiMDFhYWYwZTkzMTZkYjVlMGNkMDg1In0sInBheWxvYWQiOnsiY2FsbGJhY2siOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJwZXJtaXNzaW9ucyI6WzUsNyw4LDksMTBdfX0sInJlcXVlc3RlZENyZWRlbnRpYWxzIjpbeyJ0eXBlIjoiVmVyaWZpZWRHcmFwaEtleUNyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Il19LHsiYW55T2YiOlt7InR5cGUiOiJWZXJpZmllZEVtYWlsQWRkcmVzc0NyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFlNHFvY3poZnRpY2k0ZHpmdmZiZWw3Zm80aDRzcjVncmNvM29vdnd5azZ5NHluZjQ0dHNpIl19LHsidHlwZSI6IlZlcmlmaWVkUGhvbmVOdW1iZXJDcmVkZW50aWFsIiwiaGFzaCI6WyJiY2lxanNwbmJ3cGMzd2p4NGZld2NlazVkYXlzZGpwYmY1eGppbXo1d251NXVqN2UzdnUydXducSJdfV19XX0"
+          },
+          "frequencyRpcUrl": {
+            "type": "string",
+            "description": "A publically available Frequency node for SIWF dApps to connect to the correct chain",
+            "example": "wss://1.rpc.frequency.xyz"
+          },
+          "redirectUrl": {
+            "type": "string",
+            "description": "The compiled redirect url with all the parameters already built in",
+            "example": "https://testnet.frequencyaccess.com/siwa/start?signedRequest=eyJyZXF1ZXN0ZWRTaWduYXR1cmVzIjp7InB1YmxpY0tleSI6eyJlbmNvZGVkVmFsdWUiOiJmNmNMNHdxMUhVTngxMVRjdmRBQk5mOVVOWFhveUg0N21WVXdUNTl0elNGUlc4eURIIiwiZW5jb2RpbmciOiJiYXNlNTgiLCJmb3JtYXQiOiJzczU4IiwidHlwZSI6IlNyMjU1MTkifSwic2lnbmF0dXJlIjp7ImFsZ28iOiJTcjI1NTE5IiwiZW5jb2RpbmciOiJiYXNlMTYiLCJlbmNvZGVkVmFsdWUiOiIweDA0MDdjZTgxNGI3Nzg2MWRmOTRkMTZiM2ZjYjMxN2QzN2EwN2FiYzJhN2Y5Y2Q3YzAyY2MyMjUyOWVlN2IzMmQ1Njc5NWY4OGJkNmI0YWQxMDZiNzJiOTFiNjI0NmE3ODM2NzFiY2QyNGNiMDFhYWYwZTkzMTZkYjVlMGNkMDg1In0sInBheWxvYWQiOnsiY2FsbGJhY2siOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJwZXJtaXNzaW9ucyI6WzUsNyw4LDksMTBdfX0sInJlcXVlc3RlZENyZWRlbnRpYWxzIjpbeyJ0eXBlIjoiVmVyaWZpZWRHcmFwaEtleUNyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Il19LHsiYW55T2YiOlt7InR5cGUiOiJWZXJpZmllZEVtYWlsQWRkcmVzc0NyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFlNHFvY3poZnRpY2k0ZHpmdmZiZWw3Zm80aDRzcjVncmNvM29vdnd5azZ5NHluZjQ0dHNpIl19LHsidHlwZSI6IlZlcmlmaWVkUGhvbmVOdW1iZXJDcmVkZW50aWFsIiwiaGFzaCI6WyJiY2lxanNwbmJ3cGMzd2p4NGZld2NlazVkYXlzZGpwYmY1eGppbXo1d251NXVqN2UzdnUydXducSJdfV19XX0"
+          }
+        },
+        "required": [
+          "signedRequest",
+          "frequencyRpcUrl",
+          "redirectUrl"
+        ]
+      },
+      "WalletV2LoginRequestDto": {
+        "type": "object",
+        "properties": {
+          "authorizationCode": {
+            "type": "string",
+            "description": "The code returned from the SIWF v2 Authentication service that can be exchanged for the payload. Required unless an `authorizationPayload` is provided.",
+            "example": "680a0a68-6d3b-4d6d-89b7-0b01a6f7e86f"
+          },
+          "authorizationPayload": {
+            "type": "string",
+            "description": "The SIWF v2 Authentication payload as a JSON stringified and base64url encoded value. Required unless an `authorizationCode` is provided.",
+            "example": "ew0KICAidXNlclB1YmxpY0tleSI6IHsNCiAgICAiZW5jb2RlZFZhbHVlIjogIjVIWUhaOGU4a3lMRUJ1RWJzRmEyYndLWWJWU01nYVVoeW1mUlZnSDdDdU00VkNIdiIsDQogICAgImVuY29kaW5nIjogImJhc2U1OCIsDQogICAgImZvcm1hdCI6ICJzczU4IiwNCiAgICAidHlwZSI6ICJTcjI1NTE5Ig0KICB9LA0KICAidXNlcktleXMiOiBbDQogICAgew0KICAgICAgImVuY29kZWRQdWJsaWNLZXlWYWx1ZSI6ICIweGJkODk2ZmQ1NTAxZWVhMjU5ZjQ3OTg0MTVjOWZhNDQ3ZDU4ODIwZDk5YjkyNDA2NzFhNmYzNGYwYmMwM2IwMzAiLA0KICAgICAgImVuY29kZWRQcml2YXRlS2V5VmFsdWUiOiAiMHhmODExNWQzZTUwYzg2MTYzODZmMDY2ZjY1OTdlZmYwYzU3MGQ2N2M3ZTVjZDkzNjU1Njg4NGJjYzk5NDNmNDY0IiwNCiAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgImZvcm1hdCI6ICJiYXJlIiwNCiAgICAgICJ0eXBlIjogIlgyNTUxOSIsDQogICAgICAia2V5VHlwZSI6ICJkc25wLnB1YmxpYy1rZXkta2V5LWFncmVlbWVudCINCiAgICB9DQogIF0sDQogICJwYXlsb2FkcyI6IFsNCiAgICB7DQogICAgICAic2lnbmF0dXJlIjogew0KICAgICAgICAiYWxnbyI6ICJTUjI1NTE5IiwNCiAgICAgICAgImVuY29kaW5nIjogImJhc2UxNiIsDQogICAgICAgICJlbmNvZGVkVmFsdWUiOiAiMHgzMmFlYWViZWZmNWU4ZTEzODM3ZTg3YzQ5MWI0Mzc4MTE1MjYxZWU3NTFjYmYzYTc1ZTY5MmJiNzFhMWNmYzU3ZGRkZDhhODliYjZiNTE3ZjBiNGMyOWI0ZmFlOGUyNjQxZjM2MTEwMWNjMzg5ZmU0OTFmNTQ0NTM0ODFkZmU4OSINCiAgICAgIH0sDQogICAgICAiZW5kcG9pbnQiOiB7DQogICAgICAgICJwYWxsZXQiOiAibXNhIiwNCiAgICAgICAgImV4dHJpbnNpYyI6ICJjcmVhdGVTcG9uc29yZWRBY2NvdW50V2l0aERlbGVnYXRpb24iDQogICAgICB9LA0KICAgICAgInR5cGUiOiAiYWRkUHJvdmlkZXIiLA0KICAgICAgInBheWxvYWQiOiB7DQogICAgICAgICJhdXRob3JpemVkTXNhSWQiOiA3MjksDQogICAgICAgICJzY2hlbWFJZHMiOiBbDQogICAgICAgICAgNiwNCiAgICAgICAgICA3LA0KICAgICAgICAgIDgsDQogICAgICAgICAgOSwNCiAgICAgICAgICAxMA0KICAgICAgICBdLA0KICAgICAgICAiZXhwaXJhdGlvbiI6IDE2MDc1MzgNCiAgICAgIH0NCiAgICB9LA0KICAgIHsNCiAgICAgICJzaWduYXR1cmUiOiB7DQogICAgICAgICJhbGdvIjogIlNSMjU1MTkiLA0KICAgICAgICAiZW5jb2RpbmciOiAiYmFzZTE2IiwNCiAgICAgICAgImVuY29kZWRWYWx1ZSI6ICIweDFhMGI1ZDdkNWNhNzg4Y2VmZDE4NDk3ZDc5NzJkYTk5YzQ3NmI3NTA0YzY5MzNiYzUyYTZkZTA2NWI5NGE3NTFmMzI5Mjg5N2QzMjEzODllOTAwZmQ1MmJmMzEyYzJiZGM3ODAwZWMwMzM2YmJmMTcyY2I3ZTE5ZjU1MjJlODg0Ig0KICAgICAgfSwNCiAgICAgICJlbmRwb2ludCI6IHsNCiAgICAgICAgInBhbGxldCI6ICJoYW5kbGVzIiwNCiAgICAgICAgImV4dHJpbnNpYyI6ICJjbGFpbUhhbmRsZSINCiAgICAgIH0sDQogICAgICAidHlwZSI6ICJjbGFpbUhhbmRsZSIsDQogICAgICAicGF5bG9hZCI6IHsNCiAgICAgICAgImJhc2VIYW5kbGUiOiAid2lsd2FkZSIsDQogICAgICAgICJleHBpcmF0aW9uIjogMTYwNzUzOA0KICAgICAgfQ0KICAgIH0sDQogICAgew0KICAgICAgInNpZ25hdHVyZSI6IHsNCiAgICAgICAgImFsZ28iOiAiU1IyNTUxOSIsDQogICAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgICAiZW5jb2RlZFZhbHVlIjogIjB4YTYxN2FhMzEzMDQzMjY1NWY2MjU1ZWQ5NTE5MGE0N2MzMTc1NTk2ZDIwODlkMmE0OGY0M2QyNTdhYWM5NzY0YWZmMmU5NDNmMmNmZThlOGEwMzBmN2RkNzMwODE5NTMyMTVkNzU2YTBiYmU5OGY3MjQ5OWIwMjk3YWY5ZmQ3ODIiDQogICAgICB9LA0KICAgICAgImVuZHBvaW50Ijogew0KICAgICAgICAicGFsbGV0IjogInN0YXRlZnVsU3RvcmFnZSIsDQogICAgICAgICJleHRyaW5zaWMiOiAiYXBwbHlJdGVtQWN0aW9uc1dpdGhTaWduYXR1cmVWMiINCiAgICAgIH0sDQogICAgICAidHlwZSI6ICJpdGVtQWN0aW9ucyIsDQogICAgICAicGF5bG9hZCI6IHsNCiAgICAgICAgInNjaGVtYUlkIjogNywNCiAgICAgICAgInRhcmdldEhhc2giOiAwLA0KICAgICAgICAiZXhwaXJhdGlvbiI6IDE2MDc1MzgsDQogICAgICAgICJhY3Rpb25zIjogWw0KICAgICAgICAgIHsNCiAgICAgICAgICAgICJ0eXBlIjogImFkZEl0ZW0iLA0KICAgICAgICAgICAgInBheWxvYWRIZXgiOiAiMHhiZDg5NmZkNTUwMWVlYTI1OWY0Nzk4NDE1YzlmYTQ0N2Q1ODgyMGQ5OWI5MjQwNjcxYTZmMzRmMGJjMDNiMDMwIg0KICAgICAgICAgIH0NCiAgICAgICAgXQ0KICAgICAgfQ0KICAgIH0NCiAgXSwNCiAgImNyZWRlbnRpYWxzIjogWw0KICAgIHsNCiAgICAgICJAY29udGV4dCI6IFsNCiAgICAgICAgImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsDQogICAgICAgICJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdW5kZWZpbmVkLXRlcm1zL3YyIg0KICAgICAgXSwNCiAgICAgICJ0eXBlIjogWw0KICAgICAgICAiVmVyaWZpZWRFbWFpbEFkZHJlc3NDcmVkZW50aWFsIiwNCiAgICAgICAgIlZlcmlmaWFibGVDcmVkZW50aWFsIg0KICAgICAgXSwNCiAgICAgICJpc3N1ZXIiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20iLA0KICAgICAgInZhbGlkRnJvbSI6ICIyMDI0LTEwLTEwVDEyOjUyOjIyLjgzNyswMDAwIiwNCiAgICAgICJjcmVkZW50aWFsU2NoZW1hIjogew0KICAgICAgICAidHlwZSI6ICJKc29uU2NoZW1hIiwNCiAgICAgICAgImlkIjogImh0dHBzOi8vc2NoZW1hcy5mcmVxdWVuY3lhY2Nlc3MuY29tL1ZlcmlmaWVkRW1haWxBZGRyZXNzQ3JlZGVudGlhbC9iY2lxZTRxb2N6aGZ0aWNpNGR6ZnZmYmVsN2ZvNGg0c3I1Z3JjbzNvb3Z3eWs2eTR5bmY0NHRzaS5qc29uIg0KICAgICAgfSwNCiAgICAgICJjcmVkZW50aWFsU3ViamVjdCI6IHsNCiAgICAgICAgImlkIjogImRpZDprZXk6ejZRUDJKdlJ1WFo1d1g3N0tLOGRMOG84UWNDVm5IeTg4UnRnM2NzVXcxdFNEcGRnIiwNCiAgICAgICAgImVtYWlsQWRkcmVzcyI6ICJ3aWwud2FkZUBwcm9qZWN0bGliZXJ0eS5pbyIsDQogICAgICAgICJsYXN0VmVyaWZpZWQiOiAiMjAyNC0xMC0xMFQxMjo1MTowMi4yODMrMDAwMCINCiAgICAgIH0sDQogICAgICAicHJvb2YiOiB7DQogICAgICAgICJ0eXBlIjogIkRhdGFJbnRlZ3JpdHlQcm9vZiIsDQogICAgICAgICJ2ZXJpZmljYXRpb25NZXRob2QiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20jejZNa3c0eVg0YzJaM3NlU1NkblI5c3ZFTjZGdjdVa1U4anJOUE1rTXd0WkNvQVZHIiwNCiAgICAgICAgImNyeXB0b3N1aXRlIjogImVkZHNhLXJkZmMtMjAyMiIsDQogICAgICAgICJwcm9vZlB1cnBvc2UiOiAiYXNzZXJ0aW9uTWV0aG9kIiwNCiAgICAgICAgInByb29mVmFsdWUiOiAiejR2Y0RMdEpoY054dnZXY0F3VWNhMUs4YmFCSmNBa2JTcnBwdEhFVG1TZ0FhYjJkc2RkR0gxSjczTFQzc3czUkRjUzdWTE1HRkN1WWluNTNxVFRtNWM2TVAiDQogICAgICB9DQogICAgfSwNCiAgICB7DQogICAgICAiQGNvbnRleHQiOiBbDQogICAgICAgICJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLA0KICAgICAgICAiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3VuZGVmaW5lZC10ZXJtcy92MiINCiAgICAgIF0sDQogICAgICAidHlwZSI6IFsNCiAgICAgICAgIlZlcmlmaWVkR3JhcGhLZXlDcmVkZW50aWFsIiwNCiAgICAgICAgIlZlcmlmaWFibGVDcmVkZW50aWFsIg0KICAgICAgXSwNCiAgICAgICJpc3N1ZXIiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20iLA0KICAgICAgInZhbGlkRnJvbSI6ICIyMDI0LTEwLTEwVDEyOjUyOjIyLjgzOCswMDAwIiwNCiAgICAgICJjcmVkZW50aWFsU2NoZW1hIjogew0KICAgICAgICAidHlwZSI6ICJKc29uU2NoZW1hIiwNCiAgICAgICAgImlkIjogImh0dHBzOi8vc2NoZW1hcy5mcmVxdWVuY3lhY2Nlc3MuY29tL1ZlcmlmaWVkR3JhcGhLZXlDcmVkZW50aWFsL2JjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Lmpzb24iDQogICAgICB9LA0KICAgICAgImNyZWRlbnRpYWxTdWJqZWN0Ijogew0KICAgICAgICAiaWQiOiAiZGlkOmtleTp6NlFQMkp2UnVYWjV3WDc3S0s4ZEw4bzhRY0NWbkh5ODhSdGczY3NVdzF0U0RwZGciLA0KICAgICAgICAiZW5jb2RlZFB1YmxpY0tleVZhbHVlIjogIjB4YmQ4OTZmZDU1MDFlZWEyNTlmNDc5ODQxNWM5ZmE0NDdkNTg4MjBkOTliOTI0MDY3MWE2ZjM0ZjBiYzAzYjAzMCIsDQogICAgICAgICJlbmNvZGVkUHJpdmF0ZUtleVZhbHVlIjogIjB4ZjgxMTVkM2U1MGM4NjE2Mzg2ZjA2NmY2NTk3ZWZmMGM1NzBkNjdjN2U1Y2Q5MzY1NTY4ODRiY2M5OTQzZjQ2NCIsDQogICAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgICAiZm9ybWF0IjogImJhcmUiLA0KICAgICAgICAidHlwZSI6ICJYMjU1MTkiLA0KICAgICAgICAia2V5VHlwZSI6ICJkc25wLnB1YmxpYy1rZXkta2V5LWFncmVlbWVudCINCiAgICAgIH0sDQogICAgICAicHJvb2YiOiB7DQogICAgICAgICJ0eXBlIjogIkRhdGFJbnRlZ3JpdHlQcm9vZiIsDQogICAgICAgICJ2ZXJpZmljYXRpb25NZXRob2QiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20jejZNa3c0eVg0YzJaM3NlU1NkblI5c3ZFTjZGdjdVa1U4anJOUE1rTXd0WkNvQVZHIiwNCiAgICAgICAgImNyeXB0b3N1aXRlIjogImVkZHNhLXJkZmMtMjAyMiIsDQogICAgICAgICJwcm9vZlB1cnBvc2UiOiAiYXNzZXJ0aW9uTWV0aG9kIiwNCiAgICAgICAgInByb29mVmFsdWUiOiAiejI5YWRmdG5lSG5LeHdSOWI3Z3RSanlrTFJlR0VwdU1pWTljS0hWQ0JTejZtWThjd0ZaaUZpQVdaSGV4R3R2Qjh0YmRwZmoyRzQzeFF6dFJ6dFdhd21IRjIiDQogICAgICB9DQogICAgfQ0KICBdDQp9"
+          }
+        }
+      },
+      "GraphKeySubject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id type of the VerifiedGraphKeyCredential.",
+            "example": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1"
+          },
+          "encodedPublicKeyValue": {
+            "type": "string",
+            "description": "The encoded public key.",
+            "example": "0xb5032900293f1c9e5822fd9c120b253cb4a4dfe94c214e688e01f32db9eedf17"
+          },
+          "encodedPrivateKeyValue": {
+            "type": "string",
+            "description": "The encoded private key. WARNING: This is sensitive user information!",
+            "example": "0xd0910c853563723253c4ed105c08614fc8aaaf1b0871375520d72251496e8d87"
+          },
+          "encoding": {
+            "type": "string",
+            "description": "How the encoded keys are encoded. Only \"base16\" (aka hex) currently.",
+            "example": "base16"
+          },
+          "format": {
+            "type": "string",
+            "description": "Any addition formatting options. Only: \"bare\" currently.",
+            "example": "bare"
+          },
+          "type": {
+            "type": "string",
+            "description": "The encryption key algorithm.",
+            "example": "X25519"
+          },
+          "keyType": {
+            "type": "string",
+            "description": "The DSNP key type.",
+            "example": "dsnp.public-key-key-agreement"
+          }
+        },
+        "required": [
+          "id",
+          "encodedPublicKeyValue",
+          "encodedPrivateKeyValue",
+          "encoding",
+          "format",
+          "type",
+          "keyType"
+        ]
+      },
+      "WalletV2LoginResponseDto": {
+        "type": "object",
+        "properties": {
+          "controlKey": {
+            "type": "string",
+            "description": "The ss58 encoded MSA Control Key of the login.",
+            "example": "f6cL4wq1HUNx11TcvdABNf9UNXXoyH47mVUwT59tzSFRW8yDH"
+          },
+          "msaId": {
+            "type": "string",
+            "description": "The user's MSA Id, if one is already created. Will be empty if it is still being processed.",
+            "example": "314159265358979323846264338"
+          },
+          "email": {
+            "type": "string",
+            "description": "The users's validated email",
+            "example": "user@example.com"
+          },
+          "phoneNumber": {
+            "type": "string",
+            "description": "The users's validated SMS/Phone Number",
+            "example": "555-867-5309"
+          },
+          "graphKey": {
+            "description": "The users's Private Graph encryption key.",
+            "example": "555-867-5309",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GraphKeySubject"
+              }
+            ]
+          },
+          "rawCredentials": {
+            "description": "Raw parsed credentials received.",
+            "example": [
+              {
+                "@context": [
+                  "https://www.w3.org/ns/credentials/v2",
+                  "https://www.w3.org/ns/credentials/undefined-terms/v2"
+                ],
+                "type": [
+                  "VerifiedEmailAddressCredential",
+                  "VerifiableCredential"
+                ],
+                "issuer": "did:web:frequencyaccess.com",
+                "validFrom": "2024-08-21T21:28:08.289+0000",
+                "credentialSchema": {
+                  "type": "JsonSchema",
+                  "id": "https://schemas.frequencyaccess.com/VerifiedEmailAddressCredential/bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi.json"
+                },
+                "credentialSubject": {
+                  "id": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+                  "emailAddress": "john.doe@example.com",
+                  "lastVerified": "2024-08-21T21:27:59.309+0000"
+                },
+                "proof": {
+                  "type": "DataIntegrityProof",
+                  "verificationMethod": "did:web:frequencyaccess.com#z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
+                  "cryptosuite": "eddsa-rdfc-2022",
+                  "proofPurpose": "assertionMethod",
+                  "proofValue": "z4jArnPwuwYxLnbBirLanpkcyBpmQwmyn5f3PdTYnxhpy48qpgvHHav6warjizjvtLMg6j3FK3BqbR2nuyT2UTSWC"
+                }
+              },
+              {
+                "@context": [
+                  "https://www.w3.org/ns/credentials/v2",
+                  "https://www.w3.org/ns/credentials/undefined-terms/v2"
+                ],
+                "type": [
+                  "VerifiedGraphKeyCredential",
+                  "VerifiableCredential"
+                ],
+                "issuer": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+                "validFrom": "2024-08-21T21:28:08.289+0000",
+                "credentialSchema": {
+                  "type": "JsonSchema",
+                  "id": "https://schemas.frequencyaccess.com/VerifiedGraphKeyCredential/bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y.json"
+                },
+                "credentialSubject": {
+                  "id": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+                  "encodedPublicKeyValue": "0xb5032900293f1c9e5822fd9c120b253cb4a4dfe94c214e688e01f32db9eedf17",
+                  "encodedPrivateKeyValue": "0xd0910c853563723253c4ed105c08614fc8aaaf1b0871375520d72251496e8d87",
+                  "encoding": "base16",
+                  "format": "bare",
+                  "type": "X25519",
+                  "keyType": "dsnp.public-key-key-agreement"
+                },
+                "proof": {
+                  "type": "DataIntegrityProof",
+                  "verificationMethod": "did:key:z6MktZ15TNtrJCW2gDLFjtjmxEdhCadNCaDizWABYfneMqhA",
+                  "cryptosuite": "eddsa-rdfc-2022",
+                  "proofPurpose": "assertionMethod",
+                  "proofValue": "z2HHWwtWggZfvGqNUk4S5AAbDGqZRFXjpMYAsXXmEksGxTk4DnnkN3upCiL1mhgwHNLkxY3s8YqNyYnmpuvUke7jF"
+                }
+              }
+            ],
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "required": [
+          "controlKey"
+        ]
+      },
       "WalletLoginConfigResponseDto": {
         "type": "object",
         "properties": {
@@ -857,7 +1209,7 @@
           "signature": {
             "type": "string",
             "description": "signature of the owner",
-            "example": "0x065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85"
+            "example": "0x01065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85"
           }
         },
         "required": [
@@ -931,6 +1283,10 @@
           "delegations"
         ]
       },
+      "u32": {
+        "type": "object",
+        "properties": {}
+      },
       "DelegationResponse": {
         "type": "object",
         "properties": {
@@ -941,7 +1297,7 @@
             "type": "object"
           },
           "revokedAt": {
-            "type": "object"
+            "$ref": "#/components/schemas/u32"
           }
         },
         "required": [
@@ -1007,7 +1363,7 @@
           "signature": {
             "type": "string",
             "description": "signature of the owner",
-            "example": "0x065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85"
+            "example": "0x01065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85"
           }
         },
         "required": [
@@ -1024,12 +1380,13 @@
           "baseHandle": {
             "type": "string",
             "description": "base handle in the request",
-            "example": "handle"
+            "example": "handle",
+            "minLength": 3
           },
           "expiration": {
             "type": "number",
             "description": "expiration block number for this payload",
-            "example": "1"
+            "example": 1
           }
         },
         "required": [
@@ -1060,6 +1417,23 @@
           "proof"
         ]
       },
+      "ChangeHandlePayloadRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/HandlePayloadDto"
+          },
+          "encodedPayload": {
+            "type": "string",
+            "description": "Raw encodedPayload is scale encoded of payload in hex format",
+            "example": "0x012345"
+          }
+        },
+        "required": [
+          "payload",
+          "encodedPayload"
+        ]
+      },
       "KeysRequestPayloadDto": {
         "type": "object",
         "properties": {
@@ -1071,7 +1445,7 @@
           "expiration": {
             "type": "number",
             "description": "expiration block number for this payload",
-            "example": "1"
+            "example": 1
           },
           "newPublicKey": {
             "type": "string",
@@ -1114,24 +1488,50 @@
           "payload"
         ]
       },
+      "KeysResponse": {
+        "type": "object",
+        "properties": {
+          "msaKeys": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "msaKeys"
+        ]
+      },
+      "ItemActionType": {
+        "type": "string",
+        "description": "Action Item type",
+        "enum": [
+          "ADD_ITEM",
+          "DELETE_ITEM"
+        ]
+      },
+      "ItemActionDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "example": "ADD_ITEM",
+            "$ref": "#/components/schemas/ItemActionType"
+          },
+          "encodedPayload": {
+            "type": "string",
+            "description": "encodedPayload to be added",
+            "example": "0x1234"
+          },
+          "index": {
+            "type": "number",
+            "description": "index of the item to be deleted",
+            "example": 0
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
       "ItemizedSignaturePayloadDto": {
         "type": "object",
         "properties": {
-          "schemaId": {
-            "type": "number",
-            "description": "schemaId related to the payload",
-            "example": "1"
-          },
-          "targetHash": {
-            "type": "number",
-            "description": "targetHash related to the stateful storage",
-            "example": "1234"
-          },
-          "expiration": {
-            "type": "number",
-            "description": "expiration block number for this payload",
-            "example": "1"
-          },
           "actions": {
             "example": [
               {
@@ -1141,15 +1541,47 @@
             ],
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/ItemActionDto"
             }
+          },
+          "schemaId": {
+            "type": "number",
+            "description": "schemaId related to the payload",
+            "example": 1
+          },
+          "targetHash": {
+            "type": "number",
+            "description": "targetHash related to the stateful storage",
+            "example": 1234
+          },
+          "expiration": {
+            "type": "number",
+            "description": "expiration block number for this payload",
+            "example": 1
           }
         },
         "required": [
+          "actions",
           "schemaId",
           "targetHash",
-          "expiration",
-          "actions"
+          "expiration"
+        ]
+      },
+      "AddNewPublicKeyAgreementPayloadRequest": {
+        "type": "object",
+        "properties": {
+          "payload": {
+            "$ref": "#/components/schemas/ItemizedSignaturePayloadDto"
+          },
+          "encodedPayload": {
+            "type": "string",
+            "description": "Raw encodedPayload to be signed",
+            "example": "0x1234"
+          }
+        },
+        "required": [
+          "payload",
+          "encodedPayload"
         ]
       },
       "AddNewPublicKeyAgreementRequestDto": {

--- a/backend/openapi-specs/content-watcher.openapi.json
+++ b/backend/openapi-specs/content-watcher.openapi.json
@@ -147,7 +147,7 @@
       }
     },
     "/v1/webhooks": {
-      "put": {
+      "post": {
         "operationId": "WebhookControllerV1_registerWebhook",
         "summary": "Register a webhook to be called when new content is encountered on the chain",
         "parameters": [],

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -106,6 +106,126 @@
         }
       }
     },
+    "/auth/login/v2/siwf/verify": {
+      "post": {
+        "summary": "Verify authorization code",
+        "description": "Verifies the authorization code received from Frequency",
+        "operationId": "verifyFrequencyAccessAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyAuthRequest"
+              },
+              "examples": {
+                "withCode": {
+                  "value": {
+                    "authorizationCode": "680a0a68-6d3b-4d6d-89b7-0b01a6f7e86f"
+                  },
+                  "summary": "Using authorization code"
+                },
+                "withPayload": {
+                  "value": {
+                    "authorizationPayload": "eyJhbGciOiJIUzI1NiJ9..."
+                  },
+                  "summary": "Using authorization payload"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful verification",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyAuthResponse"
+                },
+                "examples": {
+                  "withMsaId": {
+                    "value": {
+                      "msaId": "12345"
+                    },
+                    "summary": "Direct success with MSA ID"
+                  },
+                  "withControlKey": {
+                    "value": {
+                      "controlKey": "abc123def456"
+                    },
+                    "summary": "Requires polling with control key"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid authorization code"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/v1/accounts/account/{accountId}": {
+      "get": {
+        "operationId": "getAccountForAccountId",
+        "summary": "Fetch an account given an Account Id",
+        "parameters": [
+          {
+            "name": "accountId",
+            "required": true,
+            "in": "path",
+            "description": "AccountId in hex or SS58 format",
+            "schema": {
+              "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Found account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": ["v1/accounts"]
+      }
+    },
+    "/auth/login/v2/siwf": {
+      "get": {
+        "oprationId": "authFrequencyAccess",
+        "summary": "Initiates the authentication process with Frequency-Access and returns necessary credentials and redirect URL",
+        "responses": {
+          "200": {
+            "description": "Successful response with auth initiation data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FrequencyAccessAuthResponse"
+                },
+                "example": {
+                  "signedRequest": "eyJyZXF1ZXN0ZWRTaWduYXR1cmVzIjp7InB1YmxpY0tleSI6eyJlbmNvZGVkVmFsdWUiOiJmNmNMNHdxMUhVTngxMVRjdmRBQk5mOVVOWFhveUg0N21WVXdUNTl0elNGUlc4eURIIiwiZW5jb2RpbmciOiJiYXNlNTgiLCJmb3JtYXQiOiJzczU4IiwidHlwZSI6IlNyMjU1MTkifX19",
+                  "frequencyRpcUrl": "wss://1.rpc.frequency.xyz",
+                  "redirectUrl": "https://testnet.frequencyaccess.com/siwa/start?signedRequest=abc123"
+                }
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal server error"
+        }
+      }
+    },
     "/auth/login": {
       "post": {
         "operationId": "authLogin",
@@ -165,6 +285,16 @@
         "summary": "For polling to get the created account as authCreate can take time",
         "parameters": [
           {
+            "name": "accountId",
+            "required": false,
+            "in": "query",
+            "description": "AccountId in hex or SS58 format",
+            "schema": {
+              "example": "1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N",
+              "type": "string"
+            }
+          },
+          {
             "name": "msaId",
             "in": "query",
             "description": "The user's Message Source Account ID",
@@ -184,6 +314,9 @@
           }
         ],
         "responses": {
+          "404": {
+            "description": "Content not found"
+          },
           "202": {
             "description": "Account still pending creation"
           },
@@ -552,19 +685,11 @@
                     },
                     "status": {
                       "title": "status",
-                      "enum": [
-                        "pending",
-                        "expired",
-                        "failed",
-                        "succeeded"
-                      ],
+                      "enum": ["pending", "expired", "failed", "succeeded"],
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "referenceId",
-                    "status"
-                  ]
+                  "required": ["referenceId", "status"]
                 }
               }
             }
@@ -751,6 +876,96 @@
       }
     },
     "schemas": {
+      "HandleResponse": {
+        "type": "object",
+        "properties": {
+          "base_handle": {
+            "type": "string"
+          },
+          "canonical_base": {
+            "type": "string"
+          },
+          "suffix": {
+            "type": "number"
+          }
+        },
+        "required": ["base_handle", "canonical_base", "suffix"]
+      },
+      "AccountResponse": {
+        "type": "object",
+        "properties": {
+          "msaId": {
+            "type": "string"
+          },
+          "handle": {
+            "$ref": "#/components/schemas/HandleResponse"
+          }
+        },
+        "required": ["msaId"]
+      },
+      "VerifyAuthResponse": {
+        "type": "object",
+        "description": "Response will contain msaId and controlKey",
+        "properties": {
+          "msaId": {
+            "type": "string",
+            "description": "Message Source Account ID"
+          },
+          "controlKey": {
+            "type": "string",
+            "description": "Control key for polling account status"
+          },
+          "accessToken": {
+            "type": "string",
+            "description": "Access token for the user"
+          },
+          "expires": {
+            "type": "string",
+            "description": "Expiration time for the access token"
+          }
+        }
+      },
+      "VerifyAuthRequest": {
+        "type": "object",
+        "oneOf": [
+          {
+            "required": ["authorizationCode"]
+          },
+          {
+            "required": ["authorizationPayload"]
+          }
+        ],
+        "properties": {
+          "authorizationCode": {
+            "type": "string",
+            "description": "The code returned from the SIWF v2 Authentication service that can be exchanged for the payload."
+          },
+          "authorizationPayload": {
+            "type": "string",
+            "description": "The SIWF v2 Authentication payload as a JSON stringified and base64url encoded value."
+          }
+        }
+      },
+      "FrequencyAccessAuthResponse": {
+        "type": "object",
+        "required": ["signedRequest", "frequencyRpcUrl", "redirectUrl"],
+        "properties": {
+          "signedRequest": {
+            "type": "string",
+            "description": "Base64 encoded signed request containing authentication details"
+          },
+          "frequencyRpcUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "WebSocket URL for Frequency RPC connection"
+          },
+          "redirectUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to redirect the user for authentication"
+          }
+        }
+      },
       "UploadAssetRequest": {
         "description": "Schema defining the request payload for uploading assets. Requires a list of files to upload.",
         "type": "object",
@@ -765,9 +980,7 @@
             "minItems": 1
           }
         },
-        "required": [
-          "files"
-        ]
+        "required": ["files"]
       },
       "UploadAssetResponse": {
         "description": "Schema defining the response for a successful asset upload operation. Contains identifiers for all uploaded assets.",
@@ -781,9 +994,7 @@
             }
           }
         },
-        "required": [
-          "assetIds"
-        ]
+        "required": ["assetIds"]
       },
       "ProviderResponse": {
         "type": "object",
@@ -809,35 +1020,21 @@
           },
           "network": {
             "type": "string",
-            "enum": [
-              "local",
-              "testnet",
-              "mainnet"
-            ]
+            "enum": ["local", "testnet", "mainnet"]
           }
         },
-        "required": [
-          "nodeUrl",
-          "siwfUrl",
-          "providerId",
-          "schemas",
-          "network"
-        ]
+        "required": ["nodeUrl", "siwfUrl", "providerId", "schemas", "network"]
       },
       "LoginRequest": {
         "type": "object",
         "properties": {
           "algo": {
             "type": "string",
-            "enum": [
-              "SR25519"
-            ]
+            "enum": ["SR25519"]
           },
           "encoding": {
             "type": "string",
-            "enum": [
-              "hex"
-            ]
+            "enum": ["hex"]
           },
           "encodedValue": {
             "type": "string"
@@ -846,12 +1043,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "algo",
-          "encodedValue",
-          "encoding",
-          "publicKey"
-        ]
+        "required": ["algo", "encodedValue", "encoding", "publicKey"]
       },
       "WalletLoginResponse": {
         "type": "object",
@@ -878,16 +1070,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "base_handle",
-              "canonical_base",
-              "suffix"
-            ]
+            "required": ["base_handle", "canonical_base", "suffix"]
           }
         },
-        "required": [
-          "referenceId"
-        ]
+        "required": ["referenceId"]
       },
       "WalletLoginRequest": {
         "type": "object",
@@ -900,10 +1086,7 @@
             "properties": {
               "siwsPayload": {
                 "type": "object",
-                "required": [
-                  "message",
-                  "signature"
-                ],
+                "required": ["message", "signature"],
                 "properties": {
                   "message": {
                     "type": "string"
@@ -915,9 +1098,7 @@
               },
               "error": {
                 "type": "object",
-                "required": [
-                  "message"
-                ],
+                "required": ["message"],
                 "properties": {
                   "message": {
                     "type": "string"
@@ -933,11 +1114,7 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "pallet",
-                    "extrinsicName",
-                    "encodedExtrinsic"
-                  ],
+                  "required": ["pallet", "extrinsicName", "encodedExtrinsic"],
                   "properties": {
                     "pallet": {
                       "type": "string"
@@ -953,9 +1130,7 @@
               },
               "error": {
                 "type": "object",
-                "required": [
-                  "message"
-                ],
+                "required": ["message"],
                 "properties": {
                   "message": {
                     "type": "string"
@@ -979,11 +1154,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "expires",
-          "accessToken",
-          "msaId"
-        ]
+        "required": ["expires", "accessToken", "msaId"]
       },
       "CreateIdentityRequest": {
         "type": "object",
@@ -993,18 +1164,14 @@
           },
           "algo": {
             "type": "string",
-            "enum": [
-              "SR25519"
-            ]
+            "enum": ["SR25519"]
           },
           "baseHandle": {
             "type": "string"
           },
           "encoding": {
             "type": "string",
-            "enum": [
-              "hex"
-            ]
+            "enum": ["hex"]
           },
           "expiration": {
             "type": "number"
@@ -1036,10 +1203,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "expires",
-          "accessToken"
-        ]
+        "required": ["expires", "accessToken"]
       },
       "AuthAccountResponse": {
         "type": "object",
@@ -1072,33 +1236,21 @@
                 "type": "number"
               }
             },
-            "required": [
-              "base_handle",
-              "canonical_base",
-              "suffix"
-            ]
+            "required": ["base_handle", "canonical_base", "suffix"]
           }
         },
-        "required": [
-          "msaId",
-          "accessToken",
-          "expires"
-        ]
+        "required": ["msaId", "accessToken", "expires"]
       },
       "DelegateRequest": {
         "type": "object",
         "properties": {
           "algo": {
             "type": "string",
-            "enum": [
-              "SR25519"
-            ]
+            "enum": ["SR25519"]
           },
           "encoding": {
             "type": "string",
-            "enum": [
-              "hex"
-            ]
+            "enum": ["hex"]
           },
           "encodedValue": {
             "type": "string"
@@ -1107,12 +1259,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "algo",
-          "encodedValue",
-          "encoding",
-          "publicKey"
-        ]
+        "required": ["algo", "encodedValue", "encoding", "publicKey"]
       },
       "DelegateResponse": {
         "type": "object",
@@ -1124,10 +1271,7 @@
             "type": "integer"
           }
         },
-        "required": [
-          "expires",
-          "accessToken"
-        ]
+        "required": ["expires", "accessToken"]
       },
       "HandlesResponse": {
         "type": "object",
@@ -1151,17 +1295,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "base_handle",
-              "canonical_base",
-              "suffix"
-            ]
+            "required": ["base_handle", "canonical_base", "suffix"]
           }
         },
-        "required": [
-          "publicKey",
-          "handle"
-        ]
+        "required": ["publicKey", "handle"]
       },
       "PaginatedBroadcast": {
         "type": "object",
@@ -1179,11 +1316,7 @@
             }
           }
         },
-        "required": [
-          "newestBlockNumber",
-          "oldestBlockNumber",
-          "posts"
-        ]
+        "required": ["newestBlockNumber", "oldestBlockNumber", "posts"]
       },
       "Broadcast": {
         "type": "object",
@@ -1207,12 +1340,7 @@
             "description": "Array of ReplyExtended objects"
           }
         },
-        "required": [
-          "fromId",
-          "contentHash",
-          "content",
-          "timestamp"
-        ]
+        "required": ["fromId", "contentHash", "content", "timestamp"]
       },
       "PostBroadcastResponse": {
         "type": "object",
@@ -1226,10 +1354,7 @@
             "description": "Timestamp of the post"
           }
         },
-        "required": [
-          "content",
-          "published"
-        ]
+        "required": ["content", "published"]
       },
       "BroadcastExtended": {
         "type": "object",
@@ -1256,12 +1381,7 @@
             "description": "Array of ReplyExtended objects"
           }
         },
-        "required": [
-          "fromId",
-          "contentHash",
-          "content",
-          "timestamp"
-        ]
+        "required": ["fromId", "contentHash", "content", "timestamp"]
       },
       "ReplyExtended": {
         "type": "object",
@@ -1288,12 +1408,7 @@
             "description": "Array of ReplyExtended objects"
           }
         },
-        "required": [
-          "fromId",
-          "contentHash",
-          "content",
-          "timestamp"
-        ]
+        "required": ["fromId", "contentHash", "content", "timestamp"]
       },
       "PostBroadcastRequest": {
         "type": "object",
@@ -1311,9 +1426,7 @@
             }
           }
         },
-        "required": [
-          "content"
-        ]
+        "required": ["content"]
       },
       "CreatePostRequest": {
         "type": "object",
@@ -1332,9 +1445,7 @@
             }
           }
         },
-        "required": [
-          "content"
-        ]
+        "required": ["content"]
       },
       "EditPostRequest": {
         "type": "object",
@@ -1349,11 +1460,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "content",
-          "targetAnnouncementType",
-          "targetContentHash"
-        ]
+        "required": ["content", "targetAnnouncementType", "targetContentHash"]
       },
       "Profile": {
         "type": "object",
@@ -1388,19 +1495,10 @@
                 "type": "number"
               }
             },
-            "required": [
-              "base_handle",
-              "canonical_base",
-              "suffix"
-            ]
+            "required": ["base_handle", "canonical_base", "suffix"]
           }
         },
-        "required": [
-          "fromId",
-          "contentHash",
-          "content",
-          "timestamp"
-        ]
+        "required": ["fromId", "contentHash", "content", "timestamp"]
       },
       "EditProfileRequest": {
         "type": "object",
@@ -1409,9 +1507,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "content"
-        ]
+        "required": ["content"]
       }
     }
   }

--- a/backend/types/openapi-account-service.d.ts
+++ b/backend/types/openapi-account-service.d.ts
@@ -12,6 +12,15 @@ declare namespace Components {
       msaId: string;
       handle?: HandleResponseDto;
     }
+    export interface AddNewPublicKeyAgreementPayloadRequest {
+      payload: ItemizedSignaturePayloadDto;
+      /**
+       * Raw encodedPayload to be signed
+       * example:
+       * 0x1234
+       */
+      encodedPayload: string;
+    }
     export interface AddNewPublicKeyAgreementRequestDto {
       /**
        * AccountId in hex or SS58 format
@@ -27,6 +36,15 @@ declare namespace Components {
        */
       proof: string;
     }
+    export interface ChangeHandlePayloadRequest {
+      payload: HandlePayloadDto;
+      /**
+       * Raw encodedPayload is scale encoded of payload in hex format
+       * example:
+       * 0x012345
+       */
+      encodedPayload: string;
+    }
     export interface Delegation {
       providerId: string;
       schemaDelegations: SchemaDelegation[];
@@ -37,9 +55,7 @@ declare namespace Components {
       schemaPermissions: {
         [key: string]: any;
       };
-      revokedAt: {
-        [key: string]: any;
-      };
+      revokedAt: U32;
     }
     export interface DelegationResponseV2 {
       msaId: string;
@@ -62,6 +78,50 @@ declare namespace Components {
        * Some error
        */
       message: string;
+    }
+    export interface GraphKeySubject {
+      /**
+       * The id type of the VerifiedGraphKeyCredential.
+       * example:
+       * did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1
+       */
+      id: string;
+      /**
+       * The encoded public key.
+       * example:
+       * 0xb5032900293f1c9e5822fd9c120b253cb4a4dfe94c214e688e01f32db9eedf17
+       */
+      encodedPublicKeyValue: string;
+      /**
+       * The encoded private key. WARNING: This is sensitive user information!
+       * example:
+       * 0xd0910c853563723253c4ed105c08614fc8aaaf1b0871375520d72251496e8d87
+       */
+      encodedPrivateKeyValue: string;
+      /**
+       * How the encoded keys are encoded. Only "base16" (aka hex) currently.
+       * example:
+       * base16
+       */
+      encoding: string;
+      /**
+       * Any addition formatting options. Only: "bare" currently.
+       * example:
+       * bare
+       */
+      format: string;
+      /**
+       * The encryption key algorithm.
+       * example:
+       * X25519
+       */
+      type: string;
+      /**
+       * The DSNP key type.
+       * example:
+       * dsnp.public-key-key-agreement
+       */
+      keyType: string;
     }
     export interface HandlePayloadDto {
       /**
@@ -97,7 +157,40 @@ declare namespace Components {
       canonical_base: string;
       suffix: number;
     }
+    export interface ItemActionDto {
+      /**
+       * example:
+       * ADD_ITEM
+       */
+      type: /* Action Item type */ ItemActionType;
+      /**
+       * encodedPayload to be added
+       * example:
+       * 0x1234
+       */
+      encodedPayload?: string;
+      /**
+       * index of the item to be deleted
+       * example:
+       * 0
+       */
+      index?: number;
+    }
+    /**
+     * Action Item type
+     */
+    export type ItemActionType = 'ADD_ITEM' | 'DELETE_ITEM';
     export interface ItemizedSignaturePayloadDto {
+      /**
+       * example:
+       * [
+       *   {
+       *     "type": "ADD_ITEM",
+       *     "encodedPayload": "0x1122"
+       *   }
+       * ]
+       */
+      actions: ItemActionDto[];
       /**
        * schemaId related to the payload
        * example:
@@ -116,16 +209,6 @@ declare namespace Components {
        * 1
        */
       expiration: number;
-      /**
-       * example:
-       * [
-       *   {
-       *     "type": "ADD_ITEM",
-       *     "encodedPayload": "0x1122"
-       *   }
-       * ]
-       */
-      actions: string[];
     }
     export interface KeysRequestDto {
       /**
@@ -167,6 +250,11 @@ declare namespace Components {
        * 0x0ed2f8c714efcac51ca2325cfe95637e5e0b898ae397aa365978b7348a717d0b
        */
       newPublicKey: string;
+    }
+    export interface KeysResponse {
+      msaKeys: {
+        [key: string]: any;
+      };
     }
     export interface RetireMsaPayloadResponseDto {
       /**
@@ -210,7 +298,7 @@ declare namespace Components {
       /**
        * signature of the owner
        * example:
-       * 0x065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85
+       * 0x01065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85
        */
       signature: string;
     }
@@ -242,7 +330,7 @@ declare namespace Components {
       /**
        * signature of the owner
        * example:
-       * 0x065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85
+       * 0x01065d733ca151c9e65b78f2ba77348224d31647e6913c44ad2765c6e8ba06f834dc21d8182447d01c30f84a41d90a8f2e58001d825c6f0d61b0afe89f984eec85
        */
       signature: string;
     }
@@ -296,6 +384,7 @@ declare namespace Components {
     export interface TransactionResponse {
       referenceId: string;
     }
+    export interface U32 {}
     export interface WalletLoginConfigResponseDto {
       providerId: string;
       siwfUrl: string;
@@ -326,15 +415,201 @@ declare namespace Components {
       msaId?: string;
       publicKey?: string;
     }
+    export interface WalletV2LoginRequestDto {
+      /**
+       * The code returned from the SIWF v2 Authentication service that can be exchanged for the payload. Required unless an `authorizationPayload` is provided.
+       * example:
+       * 680a0a68-6d3b-4d6d-89b7-0b01a6f7e86f
+       */
+      authorizationCode?: string;
+      /**
+       * The SIWF v2 Authentication payload as a JSON stringified and base64url encoded value. Required unless an `authorizationCode` is provided.
+       * example:
+       * ew0KICAidXNlclB1YmxpY0tleSI6IHsNCiAgICAiZW5jb2RlZFZhbHVlIjogIjVIWUhaOGU4a3lMRUJ1RWJzRmEyYndLWWJWU01nYVVoeW1mUlZnSDdDdU00VkNIdiIsDQogICAgImVuY29kaW5nIjogImJhc2U1OCIsDQogICAgImZvcm1hdCI6ICJzczU4IiwNCiAgICAidHlwZSI6ICJTcjI1NTE5Ig0KICB9LA0KICAidXNlcktleXMiOiBbDQogICAgew0KICAgICAgImVuY29kZWRQdWJsaWNLZXlWYWx1ZSI6ICIweGJkODk2ZmQ1NTAxZWVhMjU5ZjQ3OTg0MTVjOWZhNDQ3ZDU4ODIwZDk5YjkyNDA2NzFhNmYzNGYwYmMwM2IwMzAiLA0KICAgICAgImVuY29kZWRQcml2YXRlS2V5VmFsdWUiOiAiMHhmODExNWQzZTUwYzg2MTYzODZmMDY2ZjY1OTdlZmYwYzU3MGQ2N2M3ZTVjZDkzNjU1Njg4NGJjYzk5NDNmNDY0IiwNCiAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgImZvcm1hdCI6ICJiYXJlIiwNCiAgICAgICJ0eXBlIjogIlgyNTUxOSIsDQogICAgICAia2V5VHlwZSI6ICJkc25wLnB1YmxpYy1rZXkta2V5LWFncmVlbWVudCINCiAgICB9DQogIF0sDQogICJwYXlsb2FkcyI6IFsNCiAgICB7DQogICAgICAic2lnbmF0dXJlIjogew0KICAgICAgICAiYWxnbyI6ICJTUjI1NTE5IiwNCiAgICAgICAgImVuY29kaW5nIjogImJhc2UxNiIsDQogICAgICAgICJlbmNvZGVkVmFsdWUiOiAiMHgzMmFlYWViZWZmNWU4ZTEzODM3ZTg3YzQ5MWI0Mzc4MTE1MjYxZWU3NTFjYmYzYTc1ZTY5MmJiNzFhMWNmYzU3ZGRkZDhhODliYjZiNTE3ZjBiNGMyOWI0ZmFlOGUyNjQxZjM2MTEwMWNjMzg5ZmU0OTFmNTQ0NTM0ODFkZmU4OSINCiAgICAgIH0sDQogICAgICAiZW5kcG9pbnQiOiB7DQogICAgICAgICJwYWxsZXQiOiAibXNhIiwNCiAgICAgICAgImV4dHJpbnNpYyI6ICJjcmVhdGVTcG9uc29yZWRBY2NvdW50V2l0aERlbGVnYXRpb24iDQogICAgICB9LA0KICAgICAgInR5cGUiOiAiYWRkUHJvdmlkZXIiLA0KICAgICAgInBheWxvYWQiOiB7DQogICAgICAgICJhdXRob3JpemVkTXNhSWQiOiA3MjksDQogICAgICAgICJzY2hlbWFJZHMiOiBbDQogICAgICAgICAgNiwNCiAgICAgICAgICA3LA0KICAgICAgICAgIDgsDQogICAgICAgICAgOSwNCiAgICAgICAgICAxMA0KICAgICAgICBdLA0KICAgICAgICAiZXhwaXJhdGlvbiI6IDE2MDc1MzgNCiAgICAgIH0NCiAgICB9LA0KICAgIHsNCiAgICAgICJzaWduYXR1cmUiOiB7DQogICAgICAgICJhbGdvIjogIlNSMjU1MTkiLA0KICAgICAgICAiZW5jb2RpbmciOiAiYmFzZTE2IiwNCiAgICAgICAgImVuY29kZWRWYWx1ZSI6ICIweDFhMGI1ZDdkNWNhNzg4Y2VmZDE4NDk3ZDc5NzJkYTk5YzQ3NmI3NTA0YzY5MzNiYzUyYTZkZTA2NWI5NGE3NTFmMzI5Mjg5N2QzMjEzODllOTAwZmQ1MmJmMzEyYzJiZGM3ODAwZWMwMzM2YmJmMTcyY2I3ZTE5ZjU1MjJlODg0Ig0KICAgICAgfSwNCiAgICAgICJlbmRwb2ludCI6IHsNCiAgICAgICAgInBhbGxldCI6ICJoYW5kbGVzIiwNCiAgICAgICAgImV4dHJpbnNpYyI6ICJjbGFpbUhhbmRsZSINCiAgICAgIH0sDQogICAgICAidHlwZSI6ICJjbGFpbUhhbmRsZSIsDQogICAgICAicGF5bG9hZCI6IHsNCiAgICAgICAgImJhc2VIYW5kbGUiOiAid2lsd2FkZSIsDQogICAgICAgICJleHBpcmF0aW9uIjogMTYwNzUzOA0KICAgICAgfQ0KICAgIH0sDQogICAgew0KICAgICAgInNpZ25hdHVyZSI6IHsNCiAgICAgICAgImFsZ28iOiAiU1IyNTUxOSIsDQogICAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgICAiZW5jb2RlZFZhbHVlIjogIjB4YTYxN2FhMzEzMDQzMjY1NWY2MjU1ZWQ5NTE5MGE0N2MzMTc1NTk2ZDIwODlkMmE0OGY0M2QyNTdhYWM5NzY0YWZmMmU5NDNmMmNmZThlOGEwMzBmN2RkNzMwODE5NTMyMTVkNzU2YTBiYmU5OGY3MjQ5OWIwMjk3YWY5ZmQ3ODIiDQogICAgICB9LA0KICAgICAgImVuZHBvaW50Ijogew0KICAgICAgICAicGFsbGV0IjogInN0YXRlZnVsU3RvcmFnZSIsDQogICAgICAgICJleHRyaW5zaWMiOiAiYXBwbHlJdGVtQWN0aW9uc1dpdGhTaWduYXR1cmVWMiINCiAgICAgIH0sDQogICAgICAidHlwZSI6ICJpdGVtQWN0aW9ucyIsDQogICAgICAicGF5bG9hZCI6IHsNCiAgICAgICAgInNjaGVtYUlkIjogNywNCiAgICAgICAgInRhcmdldEhhc2giOiAwLA0KICAgICAgICAiZXhwaXJhdGlvbiI6IDE2MDc1MzgsDQogICAgICAgICJhY3Rpb25zIjogWw0KICAgICAgICAgIHsNCiAgICAgICAgICAgICJ0eXBlIjogImFkZEl0ZW0iLA0KICAgICAgICAgICAgInBheWxvYWRIZXgiOiAiMHhiZDg5NmZkNTUwMWVlYTI1OWY0Nzk4NDE1YzlmYTQ0N2Q1ODgyMGQ5OWI5MjQwNjcxYTZmMzRmMGJjMDNiMDMwIg0KICAgICAgICAgIH0NCiAgICAgICAgXQ0KICAgICAgfQ0KICAgIH0NCiAgXSwNCiAgImNyZWRlbnRpYWxzIjogWw0KICAgIHsNCiAgICAgICJAY29udGV4dCI6IFsNCiAgICAgICAgImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsDQogICAgICAgICJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdW5kZWZpbmVkLXRlcm1zL3YyIg0KICAgICAgXSwNCiAgICAgICJ0eXBlIjogWw0KICAgICAgICAiVmVyaWZpZWRFbWFpbEFkZHJlc3NDcmVkZW50aWFsIiwNCiAgICAgICAgIlZlcmlmaWFibGVDcmVkZW50aWFsIg0KICAgICAgXSwNCiAgICAgICJpc3N1ZXIiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20iLA0KICAgICAgInZhbGlkRnJvbSI6ICIyMDI0LTEwLTEwVDEyOjUyOjIyLjgzNyswMDAwIiwNCiAgICAgICJjcmVkZW50aWFsU2NoZW1hIjogew0KICAgICAgICAidHlwZSI6ICJKc29uU2NoZW1hIiwNCiAgICAgICAgImlkIjogImh0dHBzOi8vc2NoZW1hcy5mcmVxdWVuY3lhY2Nlc3MuY29tL1ZlcmlmaWVkRW1haWxBZGRyZXNzQ3JlZGVudGlhbC9iY2lxZTRxb2N6aGZ0aWNpNGR6ZnZmYmVsN2ZvNGg0c3I1Z3JjbzNvb3Z3eWs2eTR5bmY0NHRzaS5qc29uIg0KICAgICAgfSwNCiAgICAgICJjcmVkZW50aWFsU3ViamVjdCI6IHsNCiAgICAgICAgImlkIjogImRpZDprZXk6ejZRUDJKdlJ1WFo1d1g3N0tLOGRMOG84UWNDVm5IeTg4UnRnM2NzVXcxdFNEcGRnIiwNCiAgICAgICAgImVtYWlsQWRkcmVzcyI6ICJ3aWwud2FkZUBwcm9qZWN0bGliZXJ0eS5pbyIsDQogICAgICAgICJsYXN0VmVyaWZpZWQiOiAiMjAyNC0xMC0xMFQxMjo1MTowMi4yODMrMDAwMCINCiAgICAgIH0sDQogICAgICAicHJvb2YiOiB7DQogICAgICAgICJ0eXBlIjogIkRhdGFJbnRlZ3JpdHlQcm9vZiIsDQogICAgICAgICJ2ZXJpZmljYXRpb25NZXRob2QiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20jejZNa3c0eVg0YzJaM3NlU1NkblI5c3ZFTjZGdjdVa1U4anJOUE1rTXd0WkNvQVZHIiwNCiAgICAgICAgImNyeXB0b3N1aXRlIjogImVkZHNhLXJkZmMtMjAyMiIsDQogICAgICAgICJwcm9vZlB1cnBvc2UiOiAiYXNzZXJ0aW9uTWV0aG9kIiwNCiAgICAgICAgInByb29mVmFsdWUiOiAiejR2Y0RMdEpoY054dnZXY0F3VWNhMUs4YmFCSmNBa2JTcnBwdEhFVG1TZ0FhYjJkc2RkR0gxSjczTFQzc3czUkRjUzdWTE1HRkN1WWluNTNxVFRtNWM2TVAiDQogICAgICB9DQogICAgfSwNCiAgICB7DQogICAgICAiQGNvbnRleHQiOiBbDQogICAgICAgICJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLA0KICAgICAgICAiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3VuZGVmaW5lZC10ZXJtcy92MiINCiAgICAgIF0sDQogICAgICAidHlwZSI6IFsNCiAgICAgICAgIlZlcmlmaWVkR3JhcGhLZXlDcmVkZW50aWFsIiwNCiAgICAgICAgIlZlcmlmaWFibGVDcmVkZW50aWFsIg0KICAgICAgXSwNCiAgICAgICJpc3N1ZXIiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20iLA0KICAgICAgInZhbGlkRnJvbSI6ICIyMDI0LTEwLTEwVDEyOjUyOjIyLjgzOCswMDAwIiwNCiAgICAgICJjcmVkZW50aWFsU2NoZW1hIjogew0KICAgICAgICAidHlwZSI6ICJKc29uU2NoZW1hIiwNCiAgICAgICAgImlkIjogImh0dHBzOi8vc2NoZW1hcy5mcmVxdWVuY3lhY2Nlc3MuY29tL1ZlcmlmaWVkR3JhcGhLZXlDcmVkZW50aWFsL2JjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Lmpzb24iDQogICAgICB9LA0KICAgICAgImNyZWRlbnRpYWxTdWJqZWN0Ijogew0KICAgICAgICAiaWQiOiAiZGlkOmtleTp6NlFQMkp2UnVYWjV3WDc3S0s4ZEw4bzhRY0NWbkh5ODhSdGczY3NVdzF0U0RwZGciLA0KICAgICAgICAiZW5jb2RlZFB1YmxpY0tleVZhbHVlIjogIjB4YmQ4OTZmZDU1MDFlZWEyNTlmNDc5ODQxNWM5ZmE0NDdkNTg4MjBkOTliOTI0MDY3MWE2ZjM0ZjBiYzAzYjAzMCIsDQogICAgICAgICJlbmNvZGVkUHJpdmF0ZUtleVZhbHVlIjogIjB4ZjgxMTVkM2U1MGM4NjE2Mzg2ZjA2NmY2NTk3ZWZmMGM1NzBkNjdjN2U1Y2Q5MzY1NTY4ODRiY2M5OTQzZjQ2NCIsDQogICAgICAgICJlbmNvZGluZyI6ICJiYXNlMTYiLA0KICAgICAgICAiZm9ybWF0IjogImJhcmUiLA0KICAgICAgICAidHlwZSI6ICJYMjU1MTkiLA0KICAgICAgICAia2V5VHlwZSI6ICJkc25wLnB1YmxpYy1rZXkta2V5LWFncmVlbWVudCINCiAgICAgIH0sDQogICAgICAicHJvb2YiOiB7DQogICAgICAgICJ0eXBlIjogIkRhdGFJbnRlZ3JpdHlQcm9vZiIsDQogICAgICAgICJ2ZXJpZmljYXRpb25NZXRob2QiOiAiZGlkOndlYjp0ZXN0bmV0LmZyZXF1ZW5jeWFjY2Vzcy5jb20jejZNa3c0eVg0YzJaM3NlU1NkblI5c3ZFTjZGdjdVa1U4anJOUE1rTXd0WkNvQVZHIiwNCiAgICAgICAgImNyeXB0b3N1aXRlIjogImVkZHNhLXJkZmMtMjAyMiIsDQogICAgICAgICJwcm9vZlB1cnBvc2UiOiAiYXNzZXJ0aW9uTWV0aG9kIiwNCiAgICAgICAgInByb29mVmFsdWUiOiAiejI5YWRmdG5lSG5LeHdSOWI3Z3RSanlrTFJlR0VwdU1pWTljS0hWQ0JTejZtWThjd0ZaaUZpQVdaSGV4R3R2Qjh0YmRwZmoyRzQzeFF6dFJ6dFdhd21IRjIiDQogICAgICB9DQogICAgfQ0KICBdDQp9
+       */
+      authorizationPayload?: string;
+    }
+    export interface WalletV2LoginResponseDto {
+      /**
+       * The ss58 encoded MSA Control Key of the login.
+       * example:
+       * f6cL4wq1HUNx11TcvdABNf9UNXXoyH47mVUwT59tzSFRW8yDH
+       */
+      controlKey: string;
+      /**
+       * The user's MSA Id, if one is already created. Will be empty if it is still being processed.
+       * example:
+       * 314159265358979323846264338
+       */
+      msaId?: string;
+      /**
+       * The users's validated email
+       * example:
+       * user@example.com
+       */
+      email?: string;
+      /**
+       * The users's validated SMS/Phone Number
+       * example:
+       * 555-867-5309
+       */
+      phoneNumber?: string;
+      /**
+       * The users's Private Graph encryption key.
+       * example:
+       * 555-867-5309
+       */
+      graphKey?: {
+        /**
+         * The id type of the VerifiedGraphKeyCredential.
+         * example:
+         * did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1
+         */
+        id: string;
+        /**
+         * The encoded public key.
+         * example:
+         * 0xb5032900293f1c9e5822fd9c120b253cb4a4dfe94c214e688e01f32db9eedf17
+         */
+        encodedPublicKeyValue: string;
+        /**
+         * The encoded private key. WARNING: This is sensitive user information!
+         * example:
+         * 0xd0910c853563723253c4ed105c08614fc8aaaf1b0871375520d72251496e8d87
+         */
+        encodedPrivateKeyValue: string;
+        /**
+         * How the encoded keys are encoded. Only "base16" (aka hex) currently.
+         * example:
+         * base16
+         */
+        encoding: string;
+        /**
+         * Any addition formatting options. Only: "bare" currently.
+         * example:
+         * bare
+         */
+        format: string;
+        /**
+         * The encryption key algorithm.
+         * example:
+         * X25519
+         */
+        type: string;
+        /**
+         * The DSNP key type.
+         * example:
+         * dsnp.public-key-key-agreement
+         */
+        keyType: string;
+      };
+      /**
+       * Raw parsed credentials received.
+       * example:
+       * [
+       *   {
+       *     "@context": [
+       *       "https://www.w3.org/ns/credentials/v2",
+       *       "https://www.w3.org/ns/credentials/undefined-terms/v2"
+       *     ],
+       *     "type": [
+       *       "VerifiedEmailAddressCredential",
+       *       "VerifiableCredential"
+       *     ],
+       *     "issuer": "did:web:frequencyaccess.com",
+       *     "validFrom": "2024-08-21T21:28:08.289+0000",
+       *     "credentialSchema": {
+       *       "type": "JsonSchema",
+       *       "id": "https://schemas.frequencyaccess.com/VerifiedEmailAddressCredential/bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi.json"
+       *     },
+       *     "credentialSubject": {
+       *       "id": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+       *       "emailAddress": "john.doe@example.com",
+       *       "lastVerified": "2024-08-21T21:27:59.309+0000"
+       *     },
+       *     "proof": {
+       *       "type": "DataIntegrityProof",
+       *       "verificationMethod": "did:web:frequencyaccess.com#z6MkofWExWkUvTZeXb9TmLta5mBT6Qtj58es5Fqg1L5BCWQD",
+       *       "cryptosuite": "eddsa-rdfc-2022",
+       *       "proofPurpose": "assertionMethod",
+       *       "proofValue": "z4jArnPwuwYxLnbBirLanpkcyBpmQwmyn5f3PdTYnxhpy48qpgvHHav6warjizjvtLMg6j3FK3BqbR2nuyT2UTSWC"
+       *     }
+       *   },
+       *   {
+       *     "@context": [
+       *       "https://www.w3.org/ns/credentials/v2",
+       *       "https://www.w3.org/ns/credentials/undefined-terms/v2"
+       *     ],
+       *     "type": [
+       *       "VerifiedGraphKeyCredential",
+       *       "VerifiableCredential"
+       *     ],
+       *     "issuer": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+       *     "validFrom": "2024-08-21T21:28:08.289+0000",
+       *     "credentialSchema": {
+       *       "type": "JsonSchema",
+       *       "id": "https://schemas.frequencyaccess.com/VerifiedGraphKeyCredential/bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y.json"
+       *     },
+       *     "credentialSubject": {
+       *       "id": "did:key:z6QNucQV4AF1XMQV4kngbmnBHwYa6mVswPEGrkFrUayhttT1",
+       *       "encodedPublicKeyValue": "0xb5032900293f1c9e5822fd9c120b253cb4a4dfe94c214e688e01f32db9eedf17",
+       *       "encodedPrivateKeyValue": "0xd0910c853563723253c4ed105c08614fc8aaaf1b0871375520d72251496e8d87",
+       *       "encoding": "base16",
+       *       "format": "bare",
+       *       "type": "X25519",
+       *       "keyType": "dsnp.public-key-key-agreement"
+       *     },
+       *     "proof": {
+       *       "type": "DataIntegrityProof",
+       *       "verificationMethod": "did:key:z6MktZ15TNtrJCW2gDLFjtjmxEdhCadNCaDizWABYfneMqhA",
+       *       "cryptosuite": "eddsa-rdfc-2022",
+       *       "proofPurpose": "assertionMethod",
+       *       "proofValue": "z2HHWwtWggZfvGqNUk4S5AAbDGqZRFXjpMYAsXXmEksGxTk4DnnkN3upCiL1mhgwHNLkxY3s8YqNyYnmpuvUke7jF"
+       *     }
+       *   }
+       * ]
+       */
+      rawCredentials?: {
+        [key: string]: any;
+      }[];
+    }
+    export interface WalletV2RedirectResponseDto {
+      /**
+       * The base64url encoded JSON stringified signed request
+       * example:
+       * eyJyZXF1ZXN0ZWRTaWduYXR1cmVzIjp7InB1YmxpY0tleSI6eyJlbmNvZGVkVmFsdWUiOiJmNmNMNHdxMUhVTngxMVRjdmRBQk5mOVVOWFhveUg0N21WVXdUNTl0elNGUlc4eURIIiwiZW5jb2RpbmciOiJiYXNlNTgiLCJmb3JtYXQiOiJzczU4IiwidHlwZSI6IlNyMjU1MTkifSwic2lnbmF0dXJlIjp7ImFsZ28iOiJTcjI1NTE5IiwiZW5jb2RpbmciOiJiYXNlMTYiLCJlbmNvZGVkVmFsdWUiOiIweDA0MDdjZTgxNGI3Nzg2MWRmOTRkMTZiM2ZjYjMxN2QzN2EwN2FiYzJhN2Y5Y2Q3YzAyY2MyMjUyOWVlN2IzMmQ1Njc5NWY4OGJkNmI0YWQxMDZiNzJiOTFiNjI0NmE3ODM2NzFiY2QyNGNiMDFhYWYwZTkzMTZkYjVlMGNkMDg1In0sInBheWxvYWQiOnsiY2FsbGJhY2siOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJwZXJtaXNzaW9ucyI6WzUsNyw4LDksMTBdfX0sInJlcXVlc3RlZENyZWRlbnRpYWxzIjpbeyJ0eXBlIjoiVmVyaWZpZWRHcmFwaEtleUNyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Il19LHsiYW55T2YiOlt7InR5cGUiOiJWZXJpZmllZEVtYWlsQWRkcmVzc0NyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFlNHFvY3poZnRpY2k0ZHpmdmZiZWw3Zm80aDRzcjVncmNvM29vdnd5azZ5NHluZjQ0dHNpIl19LHsidHlwZSI6IlZlcmlmaWVkUGhvbmVOdW1iZXJDcmVkZW50aWFsIiwiaGFzaCI6WyJiY2lxanNwbmJ3cGMzd2p4NGZld2NlazVkYXlzZGpwYmY1eGppbXo1d251NXVqN2UzdnUydXducSJdfV19XX0
+       */
+      signedRequest: string;
+      /**
+       * A publically available Frequency node for SIWF dApps to connect to the correct chain
+       * example:
+       * wss://1.rpc.frequency.xyz
+       */
+      frequencyRpcUrl: string;
+      /**
+       * The compiled redirect url with all the parameters already built in
+       * example:
+       * https://testnet.frequencyaccess.com/siwa/start?signedRequest=eyJyZXF1ZXN0ZWRTaWduYXR1cmVzIjp7InB1YmxpY0tleSI6eyJlbmNvZGVkVmFsdWUiOiJmNmNMNHdxMUhVTngxMVRjdmRBQk5mOVVOWFhveUg0N21WVXdUNTl0elNGUlc4eURIIiwiZW5jb2RpbmciOiJiYXNlNTgiLCJmb3JtYXQiOiJzczU4IiwidHlwZSI6IlNyMjU1MTkifSwic2lnbmF0dXJlIjp7ImFsZ28iOiJTcjI1NTE5IiwiZW5jb2RpbmciOiJiYXNlMTYiLCJlbmNvZGVkVmFsdWUiOiIweDA0MDdjZTgxNGI3Nzg2MWRmOTRkMTZiM2ZjYjMxN2QzN2EwN2FiYzJhN2Y5Y2Q3YzAyY2MyMjUyOWVlN2IzMmQ1Njc5NWY4OGJkNmI0YWQxMDZiNzJiOTFiNjI0NmE3ODM2NzFiY2QyNGNiMDFhYWYwZTkzMTZkYjVlMGNkMDg1In0sInBheWxvYWQiOnsiY2FsbGJhY2siOiJodHRwOi8vbG9jYWxob3N0OjMwMDAiLCJwZXJtaXNzaW9ucyI6WzUsNyw4LDksMTBdfX0sInJlcXVlc3RlZENyZWRlbnRpYWxzIjpbeyJ0eXBlIjoiVmVyaWZpZWRHcmFwaEtleUNyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFtZHZteGQ1NHp2ZTVraWZ5Y2dzZHRvYWhzNWVjZjRoYWwydHMzZWV4a2dvY3ljNW9jYTJ5Il19LHsiYW55T2YiOlt7InR5cGUiOiJWZXJpZmllZEVtYWlsQWRkcmVzc0NyZWRlbnRpYWwiLCJoYXNoIjpbImJjaXFlNHFvY3poZnRpY2k0ZHpmdmZiZWw3Zm80aDRzcjVncmNvM29vdnd5azZ5NHluZjQ0dHNpIl19LHsidHlwZSI6IlZlcmlmaWVkUGhvbmVOdW1iZXJDcmVkZW50aWFsIiwiaGFzaCI6WyJiY2lxanNwbmJ3cGMzd2p4NGZld2NlazVkYXlzZGpwYmY1eGppbXo1d251NXVqN2UzdnUydXducSJdfV19XX0
+       */
+      redirectUrl: string;
+    }
   }
 }
 declare namespace Paths {
   namespace AccountsControllerV1GetAccountForAccountId {
     namespace Parameters {
+      /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
       export type AccountId = string;
     }
     export interface PathParameters {
-      accountId: Parameters.AccountId;
+      accountId: /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
+      Parameters.AccountId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.AccountResponseDto;
@@ -342,10 +617,18 @@ declare namespace Paths {
   }
   namespace AccountsControllerV1GetAccountForMsa {
     namespace Parameters {
+      /**
+       * example:
+       * 2
+       */
       export type MsaId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
+      msaId: /**
+       * example:
+       * 2
+       */
+      Parameters.MsaId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.AccountResponseDto;
@@ -353,10 +636,18 @@ declare namespace Paths {
   }
   namespace AccountsControllerV1GetRetireMsaPayload {
     namespace Parameters {
+      /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
       export type AccountId = string;
     }
     export interface PathParameters {
-      accountId: Parameters.AccountId;
+      accountId: /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
+      Parameters.AccountId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.RetireMsaPayloadResponseDto;
@@ -379,12 +670,89 @@ declare namespace Paths {
       export type $201 = Components.Schemas.WalletLoginResponseDto;
     }
   }
+  namespace AccountsControllerV2GetRedirectUrl {
+    namespace Parameters {
+      /**
+       * example:
+       * http://localhost:3000/login/callback
+       */
+      export type CallbackUrl = string;
+      /**
+       * example:
+       * [
+       *   "VerifiedGraphKeyCredential",
+       *   "VerifiedEmailAddressCredential",
+       *   "VerifiedPhoneNumberCredential"
+       * ]
+       */
+      export type Credentials = string[];
+      /**
+       * example:
+       * [
+       *   "dsnp.broadcast@v2",
+       *   "dsnp.private-follows@v1",
+       *   "dsnp.reply@v2",
+       *   "dsnp.reaction@v1",
+       *   "dsnp.tombstone@v2",
+       *   "dsnp.update@v2",
+       *   "frequency.default-token-address@v1"
+       * ]
+       */
+      export type Permissions = string[];
+    }
+    export interface QueryParameters {
+      credentials?: /**
+       * example:
+       * [
+       *   "VerifiedGraphKeyCredential",
+       *   "VerifiedEmailAddressCredential",
+       *   "VerifiedPhoneNumberCredential"
+       * ]
+       */
+      Parameters.Credentials;
+      permissions?: /**
+       * example:
+       * [
+       *   "dsnp.broadcast@v2",
+       *   "dsnp.private-follows@v1",
+       *   "dsnp.reply@v2",
+       *   "dsnp.reaction@v1",
+       *   "dsnp.tombstone@v2",
+       *   "dsnp.update@v2",
+       *   "frequency.default-token-address@v1"
+       * ]
+       */
+      Parameters.Permissions;
+      callbackUrl: /**
+       * example:
+       * http://localhost:3000/login/callback
+       */
+      Parameters.CallbackUrl;
+    }
+    namespace Responses {
+      export type $200 = Components.Schemas.WalletV2RedirectResponseDto;
+    }
+  }
+  namespace AccountsControllerV2PostSignInWithFrequency {
+    export type RequestBody = Components.Schemas.WalletV2LoginRequestDto;
+    namespace Responses {
+      export type $200 = Components.Schemas.WalletV2LoginResponseDto;
+    }
+  }
   namespace DelegationControllerV1GetDelegation {
     namespace Parameters {
+      /**
+       * example:
+       * 2
+       */
       export type MsaId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
+      msaId: /**
+       * example:
+       * 2
+       */
+      Parameters.MsaId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.DelegationResponse;
@@ -392,12 +760,28 @@ declare namespace Paths {
   }
   namespace DelegationControllerV1GetRevokeDelegationPayload {
     namespace Parameters {
+      /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
       export type AccountId = string;
+      /**
+       * example:
+       * 1
+       */
       export type ProviderId = string;
     }
     export interface PathParameters {
-      accountId: Parameters.AccountId;
-      providerId: Parameters.ProviderId;
+      accountId: /**
+       * example:
+       * 1LSLqpLWXo7A7xuiRdu6AQPnBPNJHoQSu8DBsUYJgsNEJ4N
+       */
+      Parameters.AccountId;
+      providerId: /**
+       * example:
+       * 1
+       */
+      Parameters.ProviderId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.RevokeDelegationPayloadResponseDto;
@@ -411,10 +795,18 @@ declare namespace Paths {
   }
   namespace DelegationsControllerV2GetDelegation {
     namespace Parameters {
+      /**
+       * example:
+       * 3
+       */
       export type MsaId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
+      msaId: /**
+       * example:
+       * 3
+       */
+      Parameters.MsaId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.DelegationResponseV2;
@@ -422,12 +814,28 @@ declare namespace Paths {
   }
   namespace DelegationsControllerV2GetProviderDelegation {
     namespace Parameters {
+      /**
+       * example:
+       * 3
+       */
       export type MsaId = string;
+      /**
+       * example:
+       * 1
+       */
       export type ProviderId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
-      providerId?: Parameters.ProviderId;
+      msaId: /**
+       * example:
+       * 3
+       */
+      Parameters.MsaId;
+      providerId?: /**
+       * example:
+       * 1
+       */
+      Parameters.ProviderId;
     }
     namespace Responses {
       export type $200 = Components.Schemas.DelegationResponseV2;
@@ -436,35 +844,51 @@ declare namespace Paths {
   namespace HandlesControllerV1ChangeHandle {
     export type RequestBody = Components.Schemas.HandleRequestDto;
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.TransactionResponse;
     }
   }
   namespace HandlesControllerV1CreateHandle {
     export type RequestBody = Components.Schemas.HandleRequestDto;
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.TransactionResponse;
     }
   }
   namespace HandlesControllerV1GetChangeHandlePayload {
     namespace Parameters {
+      /**
+       * example:
+       * handle
+       */
       export type NewHandle = string;
     }
     export interface PathParameters {
-      newHandle: Parameters.NewHandle;
+      newHandle: /**
+       * example:
+       * handle
+       */
+      Parameters.NewHandle;
     }
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.ChangeHandlePayloadRequest;
     }
   }
   namespace HandlesControllerV1GetHandle {
     namespace Parameters {
+      /**
+       * example:
+       * 2
+       */
       export type MsaId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
+      msaId: /**
+       * example:
+       * 2
+       */
+      Parameters.MsaId;
     }
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.HandleResponseDto;
     }
   }
   namespace HealthControllerHealthz {
@@ -485,42 +909,82 @@ declare namespace Paths {
   namespace KeysControllerV1AddKey {
     export type RequestBody = Components.Schemas.KeysRequestDto;
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.TransactionResponse;
     }
   }
   namespace KeysControllerV1AddNewPublicKeyAgreements {
     export type RequestBody = Components.Schemas.AddNewPublicKeyAgreementRequestDto;
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.TransactionResponse;
     }
   }
   namespace KeysControllerV1GetKeys {
     namespace Parameters {
+      /**
+       * example:
+       * 2
+       */
       export type MsaId = string;
     }
     export interface PathParameters {
-      msaId: Parameters.MsaId;
+      msaId: /**
+       * example:
+       * 2
+       */
+      Parameters.MsaId;
     }
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.KeysResponse;
     }
   }
   namespace KeysControllerV1GetPublicKeyAgreementsKeyPayload {
     namespace Parameters {
+      /**
+       * example:
+       * 3
+       */
       export type MsaId = string;
+      /**
+       * example:
+       * 0x0ed2f8c714efcac51ca2325cfe95637e5e0b898ae397aa365978b7348a717d0b
+       */
       export type NewKey = string;
     }
     export interface QueryParameters {
-      msaId: Parameters.MsaId;
-      newKey: Parameters.NewKey;
+      msaId: /**
+       * example:
+       * 3
+       */
+      Parameters.MsaId;
+      newKey: /**
+       * example:
+       * 0x0ed2f8c714efcac51ca2325cfe95637e5e0b898ae397aa365978b7348a717d0b
+       */
+      Parameters.NewKey;
     }
     namespace Responses {
-      export interface $200 {}
+      export type $200 = Components.Schemas.AddNewPublicKeyAgreementPayloadRequest;
     }
   }
 }
 
 export interface OperationMethods {
+  /**
+   * AccountsControllerV2_getRedirectUrl - Get the Sign In With Frequency Redirect URL
+   */
+  'AccountsControllerV2_getRedirectUrl'(
+    parameters?: Parameters<Paths.AccountsControllerV2GetRedirectUrl.QueryParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.AccountsControllerV2GetRedirectUrl.Responses.$200>;
+  /**
+   * AccountsControllerV2_postSignInWithFrequency - Process the result of a Sign In With Frequency v2 callback
+   */
+  'AccountsControllerV2_postSignInWithFrequency'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.AccountsControllerV2PostSignInWithFrequency.RequestBody,
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.AccountsControllerV2PostSignInWithFrequency.Responses.$200>;
   /**
    * AccountsControllerV1_getSIWFConfig - Get the Sign In With Frequency configuration
    */
@@ -700,6 +1164,24 @@ export interface OperationMethods {
 }
 
 export interface PathsDictionary {
+  ['/v2/accounts/siwf']: {
+    /**
+     * AccountsControllerV2_getRedirectUrl - Get the Sign In With Frequency Redirect URL
+     */
+    'get'(
+      parameters?: Parameters<Paths.AccountsControllerV2GetRedirectUrl.QueryParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.AccountsControllerV2GetRedirectUrl.Responses.$200>;
+    /**
+     * AccountsControllerV2_postSignInWithFrequency - Process the result of a Sign In With Frequency v2 callback
+     */
+    'post'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.AccountsControllerV2PostSignInWithFrequency.RequestBody,
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.AccountsControllerV2PostSignInWithFrequency.Responses.$200>;
+  };
   ['/v1/accounts/siwf']: {
     /**
      * AccountsControllerV1_getSIWFConfig - Get the Sign In With Frequency configuration

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,7 @@ x-graph-service-env: &graph-service-env
   AT_REST_ENCRYPTION_KEY_SEED: 'This should get injected as a secret'
 
 x-account-service-env: &account-service-env
+  SIWF_V2_DOMAIN: 'localhost'
   BLOCKCHAIN_SCAN_INTERVAL_SECONDS: 1
   TRUST_UNFINALIZED_BLOCKS: true
   GRAPH_ENVIRONMENT_TYPE: Mainnet

--- a/frontend/src/features/Login/Login.tsx
+++ b/frontend/src/features/Login/Login.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import { Spin } from 'antd';
 import * as dsnpLink from '../../dsnpLink';
 import { UserAccount } from '../../types';

--- a/frontend/src/features/Login/LoginForm.tsx
+++ b/frontend/src/features/Login/LoginForm.tsx
@@ -46,6 +46,16 @@ interface LoginProps {
 const LoginForm = ({ onLogin, providerId, nodeUrl, siwfUrl }: LoginProps): ReactElement => {
   const [isLoading, setIsLoading] = useState(false);
 
+  const handleLoginSiwaV2 = async () => {
+    try {
+      const context = getContext();
+      const { redirectUrl } = await dsnpLink.authLoginV2SiwfGet(context, {});
+      window.location.href = redirectUrl;
+    } catch (error) {
+      console.error('Sign in failed:', error);
+    }
+  };
+
   const handleLogin = async () => {
     setIsLoading(true);
 
@@ -187,9 +197,17 @@ const LoginForm = ({ onLogin, providerId, nodeUrl, siwfUrl }: LoginProps): React
     <Form layout="vertical" size="large">
       <Spin tip="Loading" size="large" spinning={isLoading}>
         <Form.Item label="">
-          <Button type="primary" onClick={handleLogin}>
-            Signup / Login with Frequency
-          </Button>
+          <div>
+            <Button type="primary" onClick={handleLogin}>
+              Signup / Login with Frequency
+            </Button>
+          </div>
+          <div style={{ textAlign: 'center' }}>OR</div>
+          <div>
+            <Button type="primary" onClick={handleLoginSiwaV2}>
+              Signup / Login with Frequency V2
+            </Button>
+          </div>
         </Form.Item>
       </Spin>
     </Form>

--- a/frontend/src/pages/App/App.tsx
+++ b/frontend/src/pages/App/App.tsx
@@ -86,6 +86,7 @@ const App = (): ReactElement => {
                         handlePostPublished={handlePostPublished}
                         refreshTrigger={refreshTrigger}
                         showLoginModal={() => setIsLoginModalOpen(true)}
+                        onLogin={handleLogin}
                       />
                     </AuthErrorBoundary>
                   </Col>

--- a/frontend/src/pages/Callback/Callback.tsx
+++ b/frontend/src/pages/Callback/Callback.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import * as dsnpLink from '../../dsnpLink';
+import { getContext } from '../../service/AuthService';
+import { Handle, UserAccount } from '../../types';
+import { Content } from 'antd/es/layout/layout';
+import { Alert, Button, Space, Spin, Typography } from 'antd';
+
+interface CallbackProps {
+  onLogin: (account: UserAccount, providerInfo: dsnpLink.ProviderResponse) => void;
+}
+
+interface PollingConfig {
+  maxAttempts: number;
+  intervalMs: number;
+  timeoutMs: number;
+}
+
+/**
+ * Represents an error that occurs during API calls.
+ *
+ * @class ApiError
+ * @extends {Error}
+ */
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: number,
+    public readonly attempt?: number
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+const DEFAULT_POLLING_CONFIG: PollingConfig = {
+  maxAttempts: 10,
+  intervalMs: 2000,
+  timeoutMs: 30000,
+};
+
+/**
+ * Polls for the account status until the account is created or the polling is aborted.
+ *
+ * @param {string} accountId - The ID of the account to poll for.
+ * @param {PollingConfig} [config={}] - Optional configuration for polling, such as interval and timeout.
+ * @returns {Promise<AccountStatus>} A promise that resolves to the account status once the account is created.
+ * @throws {Error} If the polling is aborted or an error occurs during polling.
+ */
+const pollForAccount = async (
+  accountId: string,
+  config: Partial<PollingConfig> = {}
+): Promise<dsnpLink.AuthAccountResponse> => {
+  const finalConfig = { ...DEFAULT_POLLING_CONFIG, ...config };
+  const startTime = Date.now();
+
+  for (let attempt = 1; attempt <= finalConfig.maxAttempts; attempt++) {
+    const elapsedTime = Date.now() - startTime;
+    if (elapsedTime > finalConfig.timeoutMs) {
+      throw new ApiError(`Polling timed out after ${finalConfig.timeoutMs}ms`, 408, attempt);
+    }
+
+    try {
+      const response = await getAccountById(accountId);
+
+      if (response && Object.keys(response).length > 0) {
+        return response;
+      }
+
+      if (attempt < finalConfig.maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, finalConfig.intervalMs));
+      }
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 404) {
+        if (attempt === finalConfig.maxAttempts) {
+          throw new ApiError(`Account not found after ${attempt} attempts`, 404, attempt);
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, finalConfig.intervalMs));
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  throw new ApiError(`Account not found after ${finalConfig.maxAttempts} attempts`, 404, finalConfig.maxAttempts);
+};
+
+interface AuthResult {
+  msaId?: string;
+  controlKey?: string;
+  accessToken: string;
+  expires: number;
+}
+
+/**
+ * Parameters required for authorization.
+ *
+ * @interface AuthParams
+ * @property {string | null} authorizationCode - The authorization code.
+ * @property {string | null} authorizationPayload - The authorization payload.
+ */
+interface AuthParams {
+  authorizationCode: string | null;
+  authorizationPayload: string | null;
+}
+
+/**
+ * Verifies the authorization using the provided parameters.
+ *
+ * @async
+ * @function verifyAuthorization
+ * @param {AuthParams} params - The parameters required for authorization.
+ * @returns {Promise<AuthResult>} A promise that resolves to the authorization result.
+ * @throws {ApiError} If the access token cannot be retrieved.
+ */
+const verifyAuthorization = async (params: AuthParams): Promise<AuthResult> => {
+  const { authorizationCode, authorizationPayload } = params;
+
+  const { msaId, controlKey, accessToken, expires } = await dsnpLink.verifyFrequencyAccessAuth(
+    getContext(),
+    {},
+    { authorizationCode, authorizationPayload }
+  );
+
+  if (!accessToken) {
+    throw new ApiError('Failed to get access token', 401);
+  }
+
+  if (!expires) {
+    throw new ApiError('Failed to get token expiration', 401);
+  }
+
+  return { msaId, controlKey, accessToken, expires: Number(expires) };
+};
+
+/**
+ * Fetches the account information by account ID.
+ *
+ * @async
+ * @function getAccountById
+ * @param {string} accountId - The ID of the account to fetch.
+ * @returns {Promise<dsnpLink.AuthAccountResponse>} A promise that resolves to the account information.
+ * @throws {ApiError} If the account is not found or another error occurs.
+ */
+const getAccountById = async (accountId: string): Promise<dsnpLink.AuthAccountResponse> => {
+  if (!accountId) {
+    throw new ApiError('Account ID is required', 400);
+  }
+
+  try {
+    const context = getContext();
+    const response = await dsnpLink.authAccount(context, { accountId });
+
+    if (!response) {
+      throw new ApiError('Account not found', 404);
+    }
+
+    return response;
+  } catch (error: any) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    if (error.code === 404) {
+      throw new ApiError('Account not found', 404);
+    }
+
+    throw new ApiError(error.message || 'Failed to fetch account', error.code || 500);
+  }
+};
+
+/**
+ * Represents the Callback component.
+ *
+ * @component
+ * @param {Object} props - The component props.
+ * @param {Function} props.onLogin - The callback function to be called when the user logs in.
+ * @returns {JSX.Element} The rendered Callback component.
+ */
+const Callback = ({ onLogin }: CallbackProps) => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState('Verifying authorization...');
+
+  const fetchAccountWithPolling = async (accountId: string): Promise<dsnpLink.AuthAccountResponse> => {
+    try {
+      const response = await pollForAccount(accountId, {
+        maxAttempts: 5,
+        intervalMs: 3000,
+        timeoutMs: 20000,
+      });
+
+      return response;
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw new ApiError('Failed to fetch account during polling', 500);
+    }
+  };
+
+  const getProviderInfo = async (): Promise<dsnpLink.ProviderResponse> => {
+    const providerInfo = await dsnpLink.authProvider(getContext(), {});
+
+    if (!providerInfo) {
+      throw new ApiError('Failed to get provider info', 404);
+    }
+
+    return providerInfo;
+  };
+
+  const createUserAccount = (msaId: string, handle: Handle, accessToken: string, expires: number): UserAccount => ({
+    msaId,
+    handle,
+    accessToken,
+    expires: Number(expires),
+  });
+
+  const handleExistingAccount = async (
+    msaId: string,
+    accessToken: string,
+    expires: number,
+    providerInfo: dsnpLink.ProviderResponse
+  ) => {
+    const { handle } = await dsnpLink.authAccount(getContext(), { msaId });
+    const userAccount = createUserAccount(msaId, handle, accessToken, expires);
+    onLogin(userAccount, providerInfo);
+  };
+
+  const handleNewAccount = async (
+    controlKey: string,
+    accessToken: string,
+    expires: number,
+    providerInfo: dsnpLink.ProviderResponse
+  ) => {
+    setStatusMessage('Creating account...');
+    const { msaId, handle } = await fetchAccountWithPolling(controlKey);
+    const userAccount = createUserAccount(msaId, handle as Handle, accessToken, expires);
+    onLogin(userAccount, providerInfo);
+  };
+
+  const handleCallback = async () => {
+    const authorizationCode = searchParams.get('authorizationCode');
+    const authorizationPayload = searchParams.get('authorizationPayload');
+
+    if (!authorizationCode && !authorizationPayload) {
+      setError('No authorization code or authorization payload provided');
+      return;
+    }
+
+    try {
+      const { msaId, controlKey, accessToken, expires } = await verifyAuthorization({
+        authorizationCode,
+        authorizationPayload,
+      });
+
+      const providerInfo = await getProviderInfo();
+
+      if (msaId) {
+        await handleExistingAccount(msaId, accessToken, expires, providerInfo);
+      } else if (controlKey) {
+        handleNewAccount(controlKey, accessToken, expires, providerInfo);
+      } else {
+        throw new Error('Invalid authentication response');
+      }
+
+      setStatusMessage('success');
+      navigate('/', { replace: true });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to verify authorization';
+      setError(errorMessage);
+      console.error('Verification error:', error);
+    }
+  };
+
+  useEffect(() => {
+    handleCallback();
+  }, []);
+
+  return (
+    <Content style={{ height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Space direction="vertical" size="large" style={{ width: '100%', textAlign: 'center' }}>
+        {error ? (
+          <>
+            <Alert message="Authentication Error" description={error} type="error" showIcon />
+            <Button onClick={() => (window.location.href = '/')} type="primary">
+              Try Again
+            </Button>
+          </>
+        ) : (
+          <>
+            <Typography.Title level={3}>{statusMessage}</Typography.Title>
+            <Spin size="large" />
+          </>
+        )}
+      </Space>
+    </Content>
+  );
+};
+
+export default Callback;

--- a/frontend/src/pages/PageRoutes.tsx
+++ b/frontend/src/pages/PageRoutes.tsx
@@ -4,6 +4,7 @@ import ProfilePage from './Profile/ProfilePage';
 import React from 'react';
 import Discover from './Discover/Discover';
 import MyFeed from './MyFeed/MyFeed';
+import Callback from './Callback/Callback';
 
 interface PageRoutesProps {
   loggedInAccount: UserAccount;
@@ -12,6 +13,7 @@ interface PageRoutesProps {
   handlePostPublished: () => void;
   refreshTrigger: number;
   showLoginModal: () => void;
+  onLogin: (account: UserAccount, providerInfo: any) => void;
 }
 
 const PageRoutes = ({
@@ -21,6 +23,7 @@ const PageRoutes = ({
   isPosting,
   refreshTrigger,
   showLoginModal,
+  onLogin,
 }: PageRoutesProps) => {
   return (
     <>
@@ -38,6 +41,7 @@ const PageRoutes = ({
             />
           }
         />
+        <Route path="/login/callback" element={<Callback onLogin={onLogin} />} />
         {loggedInAccount && (
           <>
             <Route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "social-app-template",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Introduces support for sign-in and sign-up using SIWF V2.

This update enables apps to onboard users with familiar login methods,
allowing users to authenticate with either their email or phone number,
bridging the experience for web2 users.

- Implemented backend routes to support the SIWF V2 flow
- Add a frontend button to navigate users to login with SIWF
- Created a callback page view to display account creation

![siwf sat-2024-10-29-214721](https://github.com/user-attachments/assets/082ee079-6892-4412-abd0-a0c0c0b29a28)

Closes #170
