### PR TITLE
fix: update for gateway 1.4.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ x-graph-service-env: &graph-service-env
   AT_REST_ENCRYPTION_KEY_SEED: 'This should get injected as a secret'
 
 x-account-service-env: &account-service-env
-  SIWF_V2_DOMAIN: 'localhost'
+  SIWF_V2_URI_VALIDATION: 'localhost'
   BLOCKCHAIN_SCAN_INTERVAL_SECONDS: 1
   TRUST_UNFINALIZED_BLOCKS: true
   GRAPH_ENVIRONMENT_TYPE: Mainnet

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -117,7 +117,6 @@ services:
 
   content-publishing-service-api:
     image: projectlibertylabs/content-publishing-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     ports:
       - ${SERVICE_PORT_0}:3000
@@ -132,7 +131,6 @@ services:
 
   content-publishing-service-worker:
     image: projectlibertylabs/content-publishing-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     environment:
       <<: [*common-environment, *content-publishing-env]
@@ -146,7 +144,6 @@ services:
 
   content-watcher-service:
     image: projectlibertylabs/content-watcher-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     ports:
       - ${SERVICE_PORT_1}:3000
@@ -161,7 +158,6 @@ services:
 
   graph-service-api:
     image: projectlibertylabs/graph-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     ports:
       - ${SERVICE_PORT_2}:3000
@@ -177,7 +173,6 @@ services:
 
   graph-service-worker:
     image: projectlibertylabs/graph-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     environment:
       <<: [*common-environment, *graph-service-env]
@@ -191,7 +186,6 @@ services:
 
   account-service-api:
     image: projectlibertylabs/account-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     ports:
       - ${SERVICE_PORT_3}:3000
@@ -207,7 +201,6 @@ services:
 
   account-service-worker:
     image: projectlibertylabs/account-service:${DOCKER_TAG:-latest}
-    platform: linux/amd64
     pull_policy: always
     command: account-worker
     environment:

--- a/start.sh
+++ b/start.sh
@@ -347,4 +347,4 @@ SERVICES_STR="${SERVICES_STR}
 "
 fi
 
-box_text_attention "${SERVICES_STR}"
+box_text_attention -w 0 "${SERVICES_STR}"


### PR DESCRIPTION
# Purpose
The goal of this PR is to allow social-app-template to work with gateway containers v1.4.0

## Solution

Update `SIWF_V2_DOMAIN` to `SIWF_V2_URI_VALIDATION` in `docker-compose.yaml`

## Steps to Verify
1. Remove existing gateway containers from docker desktop or your preferred container service.
2. Execute `start.sh` and verify that social-app-template runs with the new containers.

