### PR TITLE
fix: start.sh support for ubuntu. Also for quick WSL tests

### DIFF
--- a/bash_functions.sh
+++ b/bash_functions.sh
@@ -14,13 +14,13 @@ BOX_WIDTH=96
 #  If we don't find one, disable our "pretty" output function.
 ###################################################################################
 PCRE_GREP=
-if 2>/dev/null 1>/dev/null grep -q -P "foo"; then
+if echo "foobar" | grep -q -P "foo(?=bar)" >/dev/null 2>&1; then
     PCRE_GREP=grep
 else
     # Grep is not PCRE compatible, check for other greps
     if command -v ggrep >/dev/null; then # MacOS Homebrew might have ggrep
         PCRE_GREP=ggrep
-    elif command -v prce2grep > /dev/null; then # MacOS Homebrew could also have pcre2grep
+    elif command -v pcre2grep > /dev/null; then # MacOS Homebrew could also have pcre2grep
         PCRE_GREP=pcre2grep
     fi
 fi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -104,8 +104,8 @@ services:
     image: ipfs/kubo:latest
     ports:
       - 4001:4001
-      - 127.0.0.1:5001:5001
-      - 127.0.0.1:8080:8080
+      - 5001:5001
+      - 8080:8080
     networks:
       - social-app-backend
     volumes:


### PR DESCRIPTION
To fix https://github.com/ProjectLibertyLabs/social-app-template/issues/185

Also made it so when run in WSL that it can be accessed on LAN for localized testing in case the frequency node is not local to the host device.